### PR TITLE
Disable flake8 E402

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+ignore = E402


### PR DESCRIPTION
Disables flake8's check for "module level import not at top of file" across the board.