### PR TITLE
idr0010: fix pattern files

### DIFF
--- a/idr0010-doil-dnadamage/make_patterns.py
+++ b/idr0010-doil-dnadamage/make_patterns.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+from pyidr import file_pattern as fp
+from glob import glob
+from os.path import basename
+
+base = "/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/"
+plates = "idr-metadata/idr0010-doil-dnadamage/screenA/plates/"
+dirs = glob(base + "/*")
+
+def iglob(pattern):
+  def either(c):
+    return '[%s%s]'%(c.lower(),c.upper()) if c.isalpha() else c
+  return glob(''.join(map(either,pattern)))
+
+
+for dir in dirs:
+  try:
+    dapi, = [x for x in iglob(dir + "/*dapi*") if "spot" not in x]
+    try:
+      bp, = [x for x in iglob(dir + "/*bp*") if "spot" not in x]
+    except: # Try BB
+      bp, = [x for x in iglob(dir + "/*bb*") if "spot" not in x]
+  except:
+    raise Exception(dir)
+
+  plate = basename(dir)  
+  bp = bp.replace("bp", "bxxx")
+  rv = fp.find_pattern_2seq(dapi, bp)
+  rv = rv.replace("bxxx", "bp")
+  print plate, " ".join(rv.split("/")[-1].split(" ")[1:])
+  with open("%s/%s" % (plates, plate), "w") as screen_file:
+      screen_file.write("%s/%s.pattern\n" % (plates, plate))
+  with open("%s/%s.pattern" % (plates, plate), "w") as pattern_file:
+      pattern_file.write(rv)

--- a/idr0010-doil-dnadamage/screenA/idr0010-screenA-plates.tsv
+++ b/idr0010-doil-dnadamage/screenA/idr0010-screenA-plates.tsv
@@ -1,149 +1,149 @@
-1-23	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/1-23/1-23.pattern
-10-34	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/10-34/10-34.pattern
-100-27	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/100-27/100-27.pattern
-101-24	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/101-24/101-24.pattern
-102	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/102/102.pattern
-103	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/103/103.pattern
-104-13	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/104-13/104-13.pattern
-105-12	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/105-12/105-12.pattern
-106-13	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/106-13/106-13.pattern
-107	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/107/107.pattern
-108-24	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/108-24/108-24.pattern
-109-36	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/109-36/109-36.pattern
-11-08	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/11-08/11-08.pattern
-110-35	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/110-35/110-35.pattern
-111-07	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/111-07/111-07.pattern
-112-02	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/112-02/112-02.pattern
-113-34	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/113-34/113-34.pattern
-114-58	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/114-58/114-58.pattern
-115-11	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/115-11/115-11.pattern
-116-25	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/116-25/116-25.pattern
-117-12	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/117-12/117-12.pattern
-118-33	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/118-33/118-33.pattern
-119-43	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/119-43/119-43.pattern
-12-23	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/12-23/12-23.pattern
-120	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/120/120.pattern
-121-11	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/121-11/121-11.pattern
-122-42	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/122-42/122-42.pattern
-123-18	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/123-18/123-18.pattern
-124-44	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/124-44/124-44.pattern
-125-27	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/125-27/125-27.pattern
-126-12	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/126-12/126-12.pattern
-127-44	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/127-44/127-44.pattern
-128-35	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/128-35/128-35.pattern
-129-58	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/129-58/129-58.pattern
-13-3	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/13-3/13-3.pattern
-130-16	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/130-16/130-16.pattern
-131-20	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/131-20/131-20.pattern
-132-19	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/132-19/132-19.pattern
-133-29	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/133-29/133-29.pattern
-134-34	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/134-34/134-34.pattern
-135-21	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/135-21/135-21.pattern
-136-19	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/136-19/136-19.pattern
-137-11	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/137-11/137-11.pattern
-138-27	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/138-27/138-27.pattern
-139-29	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/139-29/139-29.pattern
-14-35	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/14-35/14-35.pattern
-140-35	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/140-35/140-35.pattern
-141-27	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/141-27/141-27.pattern
-142-29	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/142-29/142-29.pattern
-143-29	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/143-29/143-29.pattern
-144-21	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/144-21/144-21.pattern
-145-20	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/145-20/145-20.pattern
-146-35	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/146-35/146-35.pattern
-147-09	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/147-09/147-09.pattern
-148-48	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/148-48/148-48.pattern
-149-21	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/149-21/149-21.pattern
-15-11	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/15-11/15-11.pattern
-150-15	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/150-15/150-15.pattern
-151-48	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/151-48/151-48.pattern
-152-14	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/152-14/152-14.pattern
-153-29	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/153-29/153-29.pattern
-154-43	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/154-43/154-43.pattern
-155-45	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/155-45/155-45.pattern
-156-42	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/156-42/156-42.pattern
-157-46	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/157-46/157-46.pattern
-158-10	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/158-10/158-10.pattern
-159-13	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/159-13/159-13.pattern
-16-45	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/16-45/16-45.pattern
-17-43	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/17-43/17-43.pattern
-18-18	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/18-18/18-18.pattern
-19-29	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/19-29/19-29.pattern
-2-60	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/2-60/2-60.pattern
-20-29	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/20-29/20-29.pattern
-21-58	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/21-58/21-58.pattern
-22-21	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/22-21/22-21.pattern
-23-15	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/23-15/23-15.pattern
-24-27	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/24-27/24-27.pattern
-25-28	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/25-28/25-28.pattern
-26-41	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/26-41/26-41.pattern
-27-37	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/27-37/27-37.pattern
-28-43	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/28-43/28-43.pattern
-29-30	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/29-30/29-30.pattern
-3-11	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/3-11/3-11.pattern
-30-44	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/30-44/30-44.pattern
-31-48	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/31-48/31-48.pattern
-32-42	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/32-42/32-42.pattern
-33-46	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/33-46/33-46.pattern
-34-30	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/34-30/34-30.pattern
-35-18	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/35-18/35-18.pattern
-36-28	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/36-28/36-28.pattern
-37-34	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/37-34/37-34.pattern
-38-21	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/38-21/38-21.pattern
-39-44	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/39-44/39-44.pattern
-4-36	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/4-36/4-36.pattern
-40-37	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/40-37/40-37.pattern
-41-31	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/41-31/41-31.pattern
-42-44	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/42-44/42-44.pattern
-43-04	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/43-04/43-04.pattern
-44-13	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/44-13/44-13.pattern
-45-31	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/45-31/45-31.pattern
-46-33	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/46-33/46-33.pattern
-47-35	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/47-35/47-35.pattern
-48-29	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/48-29/48-29.pattern
-49-06	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/49-06/49-06.pattern
-5-12	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/5-12/5-12.pattern
-6-14	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/6-14/6-14.pattern
-60-30	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/60-30/60-30.pattern
-61-43	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/61-43/61-43.pattern
-62-01	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/62-01/62-01.pattern
-63-27	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/63-27/63-27.pattern
-64-41	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/64-41/64-41.pattern
-65-12	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/65-12/65-12.pattern
-66-37	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/66-37/66-37.pattern
-67-44	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/67-44/67-44.pattern
-68-30	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/68-30/68-30.pattern
-69-49	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/69-49/69-49.pattern
-7-14	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/7-14/7-14.pattern
-70-12	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/70-12/70-12.pattern
-71-19	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/71-19/71-19.pattern
-72-33	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/72-33/72-33.pattern
-73-40	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/73-40/73-40.pattern
-74-26	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/74-26/74-26.pattern
-75-33	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/75-33/75-33.pattern
-76-45	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/76-45/76-45.pattern
-77-20	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/77-20/77-20.pattern
-78-31	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/78-31/78-31.pattern
-79-39	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/79-39/79-39.pattern
-8-10	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/8-10/8-10.pattern
-80-29	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/80-29/80-29.pattern
-81-44	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/81-44/81-44.pattern
-82-14	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/82-14/82-14.pattern
-83-48	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/83-48/83-48.pattern
-84-33	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/84-33/84-33.pattern
-85	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/85/85.pattern
-86-31	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/86-31/86-31.pattern
-87-48	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/87-48/87-48.pattern
-88-40	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/88-40/88-40.pattern
-89-16	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/89-16/89-16.pattern
-9-12	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/9-12/9-12.pattern
-90-27	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/90-27/90-27.pattern
-91-29	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/91-29/91-29.pattern
-92-44	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/92-44/92-44.pattern
-93-40	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/93-40/93-40.pattern
-94-05	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/94-05/94-05.pattern
-95-48	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/95-48/95-48.pattern
-96-14	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/96-14/96-14.pattern
-97	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/97/97.pattern
-98-23	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/98-23/98-23.pattern
-99	/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/99/99.pattern
+1-23	plates/1-23.pattern
+10-34	plates/10-34.pattern
+100-27	plates/100-27.pattern
+101-24	plates/101-24.pattern
+102	plates/102.pattern
+103	plates/103.pattern
+104-13	plates/104-13.pattern
+105-12	plates/105-12.pattern
+106-13	plates/106-13.pattern
+107	plates/107.pattern
+108-24	plates/108-24.pattern
+109-36	plates/109-36.pattern
+11-08	plates/11-08.pattern
+110-35	plates/110-35.pattern
+111-07	plates/111-07.pattern
+112-02	plates/112-02.pattern
+113-34	plates/113-34.pattern
+114-58	plates/114-58.pattern
+115-11	plates/115-11.pattern
+116-25	plates/116-25.pattern
+117-12	plates/117-12.pattern
+118-33	plates/118-33.pattern
+119-43	plates/119-43.pattern
+12-23	plates/12-23.pattern
+120	plates/120.pattern
+121-11	plates/121-11.pattern
+122-42	plates/122-42.pattern
+123-18	plates/123-18.pattern
+124-44	plates/124-44.pattern
+125-27	plates/125-27.pattern
+126-12	plates/126-12.pattern
+127-44	plates/127-44.pattern
+128-35	plates/128-35.pattern
+129-58	plates/129-58.pattern
+13-3	plates/13-3.pattern
+130-16	plates/130-16.pattern
+131-20	plates/131-20.pattern
+132-19	plates/132-19.pattern
+133-29	plates/133-29.pattern
+134-34	plates/134-34.pattern
+135-21	plates/135-21.pattern
+136-19	plates/136-19.pattern
+137-11	plates/137-11.pattern
+138-27	plates/138-27.pattern
+139-29	plates/139-29.pattern
+14-35	plates/14-35.pattern
+140-35	plates/140-35.pattern
+141-27	plates/141-27.pattern
+142-29	plates/142-29.pattern
+143-29	plates/143-29.pattern
+144-21	plates/144-21.pattern
+145-20	plates/145-20.pattern
+146-35	plates/146-35.pattern
+147-09	plates/147-09.pattern
+148-48	plates/148-48.pattern
+149-21	plates/149-21.pattern
+15-11	plates/15-11.pattern
+150-15	plates/150-15.pattern
+151-48	plates/151-48.pattern
+152-14	plates/152-14.pattern
+153-29	plates/153-29.pattern
+154-43	plates/154-43.pattern
+155-45	plates/155-45.pattern
+156-42	plates/156-42.pattern
+157-46	plates/157-46.pattern
+158-10	plates/158-10.pattern
+159-13	plates/159-13.pattern
+16-45	plates/16-45.pattern
+17-43	plates/17-43.pattern
+18-18	plates/18-18.pattern
+19-29	plates/19-29.pattern
+2-60	plates/2-60.pattern
+20-29	plates/20-29.pattern
+21-58	plates/21-58.pattern
+22-21	plates/22-21.pattern
+23-15	plates/23-15.pattern
+24-27	plates/24-27.pattern
+25-28	plates/25-28.pattern
+26-41	plates/26-41.pattern
+27-37	plates/27-37.pattern
+28-43	plates/28-43.pattern
+29-30	plates/29-30.pattern
+3-11	plates/3-11.pattern
+30-44	plates/30-44.pattern
+31-48	plates/31-48.pattern
+32-42	plates/32-42.pattern
+33-46	plates/33-46.pattern
+34-30	plates/34-30.pattern
+35-18	plates/35-18.pattern
+36-28	plates/36-28.pattern
+37-34	plates/37-34.pattern
+38-21	plates/38-21.pattern
+39-44	plates/39-44.pattern
+4-36	plates/4-36.pattern
+40-37	plates/40-37.pattern
+41-31	plates/41-31.pattern
+42-44	plates/42-44.pattern
+43-04	plates/43-04.pattern
+44-13	plates/44-13.pattern
+45-31	plates/45-31.pattern
+46-33	plates/46-33.pattern
+47-35	plates/47-35.pattern
+48-29	plates/48-29.pattern
+49-06	plates/49-06.pattern
+5-12	plates/5-12.pattern
+6-14	plates/6-14.pattern
+60-30	plates/60-30.pattern
+61-43	plates/61-43.pattern
+62-01	plates/62-01.pattern
+63-27	plates/63-27.pattern
+64-41	plates/64-41.pattern
+65-12	plates/65-12.pattern
+66-37	plates/66-37.pattern
+67-44	plates/67-44.pattern
+68-30	plates/68-30.pattern
+69-49	plates/69-49.pattern
+7-14	plates/7-14.pattern
+70-12	plates/70-12.pattern
+71-19	plates/71-19.pattern
+72-33	plates/72-33.pattern
+73-40	plates/73-40.pattern
+74-26	plates/74-26.pattern
+75-33	plates/75-33.pattern
+76-45	plates/76-45.pattern
+77-20	plates/77-20.pattern
+78-31	plates/78-31.pattern
+79-39	plates/79-39.pattern
+8-10	plates/8-10.pattern
+80-29	plates/80-29.pattern
+81-44	plates/81-44.pattern
+82-14	plates/82-14.pattern
+83-48	plates/83-48.pattern
+84-33	plates/84-33.pattern
+85	plates/85.pattern
+86-31	plates/86-31.pattern
+87-48	plates/87-48.pattern
+88-40	plates/88-40.pattern
+89-16	plates/89-16.pattern
+9-12	plates/9-12.pattern
+90-27	plates/90-27.pattern
+91-29	plates/91-29.pattern
+92-44	plates/92-44.pattern
+93-40	plates/93-40.pattern
+94-05	plates/94-05.pattern
+95-48	plates/95-48.pattern
+96-14	plates/96-14.pattern
+97	plates/97.pattern
+98-23	plates/98-23.pattern
+99	plates/99.pattern

--- a/idr0010-doil-dnadamage/screenA/plates/1-23.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/1-23.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/1-23/001-23 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/10-34.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/10-34.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/10-34/0010-34 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/100-27.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/100-27.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/100-27/100-27 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/101-24.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/101-24.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/101-24/101-24 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/102.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/102.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/102/102 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/103.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/103.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/103/103-25 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/104-13.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/104-13.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/104-13/104-13 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/105-12.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/105-12.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/105-12/105-12 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/106-13.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/106-13.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/106-13/106-13 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/107.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/107.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/107/107 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/108-24.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/108-24.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/108-24/108-24 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/109-36.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/109-36.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/109-36/109-36 <dapi,53BP1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/11-08.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/11-08.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/11-08/0011-08 <Dapi,53BP1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/110-35.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/110-35.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/110-35/110-35 <dapi,53BP1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/111-07.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/111-07.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/111-07/111-07 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/112-02.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/112-02.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/112-02/112-02 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/113-34.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/113-34.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/113-34/113-34 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/114-58.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/114-58.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/114-58/114-58 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/115-11.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/115-11.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/115-11/115-11 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/116-25.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/116-25.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/116-25/116-25 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/117-12.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/117-12.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/117-12/117-12 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/118-33.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/118-33.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/118-33/118-33 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/119-43.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/119-43.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/119-43/119-43 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/12-23.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/12-23.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/12-23/012-23 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/120.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/120.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/120/120-13 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/121-11.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/121-11.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/121-11/121 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/122-42.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/122-42.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/122-42/122-42 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/123-18.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/123-18.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/123-18/123-18 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/124-44.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/124-44.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/124-44/124-44 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/125-27.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/125-27.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/125-27/125-27 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/126-12.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/126-12.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/126-12/126-12 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/127-44.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/127-44.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/127-44/127-44 <dapi, bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/128-35.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/128-35.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/128-35/128-35 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/129-58.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/129-58.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/129-58/129-58 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/13-3.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/13-3.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/13-3/0013-3 <dapi,53bp1> mv.stk

--- a/idr0010-doil-dnadamage/screenA/plates/130-16.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/130-16.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/130-16/130-16 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/131-20.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/131-20.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/131-20/131-22 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/132-19.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/132-19.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/132-19/132-19 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/133-29.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/133-29.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/133-29/133-29 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/134-34.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/134-34.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/134-34/134-34 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/135-21.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/135-21.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/135-21/135-21 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/136-19.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/136-19.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/136-19/136-19 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/137-11.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/137-11.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/137-11/137 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/138-27.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/138-27.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/138-27/138-27 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/139-29.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/139-29.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/139-29/139-29 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/14-35.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/14-35.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/14-35/0014-35 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/140-35.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/140-35.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/140-35/140-35 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/141-27.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/141-27.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/141-27/141-27 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/142-29.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/142-29.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/142-29/142-29 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/143-29.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/143-29.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/143-29/143-29 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/144-21.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/144-21.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/144-21/144-21 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/145-20.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/145-20.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/145-20/145-20 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/146-35.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/146-35.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/146-35/146-35 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/147-09.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/147-09.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/147-09/147-09 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/148-48.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/148-48.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/148-48/148-48 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/149-21.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/149-21.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/149-21/149-21 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/15-11.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/15-11.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/15-11/0015-11 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/150-15.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/150-15.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/150-15/150-15 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/151-48.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/151-48.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/151-48/151-48 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/152-14.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/152-14.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/152-14/152-14 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/153-29.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/153-29.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/153-29/153-29 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/154-43.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/154-43.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/154-43/154-43 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/155-45.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/155-45.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/155-45/155-45 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/156-42.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/156-42.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/156-42/156-42 <dapi, bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/157-46.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/157-46.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/157-46/157-46 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/158-10.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/158-10.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/158-10/158 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/159-13.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/159-13.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/159-13/159-13 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/16-45.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/16-45.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/16-45/0016-45 <Dapi,53BP1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/17-43.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/17-43.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/17-43/0017-43 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/18-18.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/18-18.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/18-18/0018-18 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/19-29.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/19-29.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/19-29/0019-29 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/2-60.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/2-60.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/2-60/0002-60 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/20-29.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/20-29.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/20-29/0020-29 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/21-58.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/21-58.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/21-58/0021-58 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/22-21.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/22-21.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/22-21/0022-21 <Dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/23-15.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/23-15.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/23-15/0023-15 <dapi,53BP1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/24-27.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/24-27.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/24-27/0024-27 <Dapi,53BP1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/25-28.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/25-28.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/25-28/0025-28 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/26-41.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/26-41.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/26-41/0026-41 <Dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/27-37.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/27-37.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/27-37/0027-37 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/28-43.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/28-43.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/28-43/0028-43 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/29-30.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/29-30.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/29-30/0029-30 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/3-11.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/3-11.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/3-11/0003-11 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/30-44.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/30-44.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/30-44/0030-44 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/31-48.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/31-48.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/31-48/0031-48 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/32-42.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/32-42.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/32-42/0032-42 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/33-46.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/33-46.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/33-46/33-46 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/34-30.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/34-30.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/34-30/0034-30 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/35-18.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/35-18.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/35-18/0035-18 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/36-28.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/36-28.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/36-28/0036-28 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/37-34.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/37-34.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/37-34/0037-34 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/38-21.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/38-21.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/38-21/0038-21 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/39-44.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/39-44.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/39-44/0039-44 <Dapi,53BP1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/4-36.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/4-36.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/4-36/0004-36 <dapi,53bp1> mv.stk

--- a/idr0010-doil-dnadamage/screenA/plates/40-37.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/40-37.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/40-37/0040-37 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/41-31.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/41-31.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/41-31/0041-31 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/42-44.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/42-44.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/42-44/0042-44 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/43-04.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/43-04.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/43-04/0043-04 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/44-13.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/44-13.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/44-13/0044-13 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/45-31.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/45-31.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/45-31/0045-31 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/46-33.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/46-33.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/46-33/0046-33 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/47-35.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/47-35.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/47-35/0047-<-,>35 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/48-29.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/48-29.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/48-29/0048-29 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/49-06.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/49-06.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/49-06/0049-06 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/5-12.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/5-12.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/5-12/0005-12 <Dapi,53BP1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/6-14.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/6-14.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/6-14/0006-14 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/60-30.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/60-30.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/60-30/60 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/61-43.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/61-43.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/61-43/61 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/62-01.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/62-01.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/62-01/62 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/63-27.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/63-27.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/63-27/63 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/64-41.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/64-41.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/64-41/0064-41 <Dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/65-12.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/65-12.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/65-12/65 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/66-37.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/66-37.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/66-37/66 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/67-44.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/67-44.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/67-44/67 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/68-30.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/68-30.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/68-30/68-30 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/69-49.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/69-49.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/69-49/0069-<6,4>9 <Dapi,53BP1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/7-14.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/7-14.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/7-14/0007-14 <Dapi,53BP1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/70-12.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/70-12.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/70-12/70 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/71-19.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/71-19.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/71-19/71 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/72-33.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/72-33.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/72-33/72 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/73-40.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/73-40.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/73-40/73-40 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/74-26.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/74-26.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/74-26/74 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/75-33.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/75-33.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/75-33/75 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/76-45.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/76-45.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/76-45/76-45 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/77-20.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/77-20.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/77-20/0077-20 <Dapi,53BP1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/78-31.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/78-31.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/78-31/78-31 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/79-39.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/79-39.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/79-39/79 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/8-10.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/8-10.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/8-10/0008-10 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/80-29.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/80-29.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/80-29/80 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/81-44.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/81-44.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/81-44/0081-44 <Dapi,53BB1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/82-14.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/82-14.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/82-14/82-14 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/83-48.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/83-48.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/83-48/83-48 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/84-33.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/84-33.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/84-33/84 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/85.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/85.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/85/85-25 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/86-31.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/86-31.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/86-31/86-31 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/87-48.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/87-48.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/87-48/87-48 <dapi,bp1> good.stk

--- a/idr0010-doil-dnadamage/screenA/plates/88-40.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/88-40.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/88-40/88-40 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/89-16.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/89-16.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/89-16/89-16 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/9-12.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/9-12.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/9-12/0009-12 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/90-27.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/90-27.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/90-27/90-27 <dapi,bp1 >.stk

--- a/idr0010-doil-dnadamage/screenA/plates/91-29.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/91-29.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/91-29/91-29 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/92-44.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/92-44.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/92-44/92-44 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/93-40.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/93-40.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/93-40/93-40 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/94-05.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/94-05.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/94-05/94-05 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/95-48.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/95-48.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/95-48/95-48 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/96-14.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/96-14.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/96-14/9<6,4>-14 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/97.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/97.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/97/97-37 <dapi,53bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/98-23.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/98-23.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/98-23/98-23 <dapi,bp1>.stk

--- a/idr0010-doil-dnadamage/screenA/plates/99.pattern
+++ b/idr0010-doil-dnadamage/screenA/plates/99.pattern
@@ -1,0 +1,1 @@
+/uod/idr/filesets/idr0010-doil-dnadamage/20150501-original/Restored GW screen/99/99-02 <dapi,bp1>.stk


### PR DESCRIPTION
The diversity of patterns for the STK files (https://trello.com/c/vpc8NKAC/163-idr0010-metamorph-stk-per-channel#comment-57205eb8bcd59093cf98b82b) required more than a simple script. This makes uses of @simleo's `find_pattern_2seq` along with a few hacks. More manual modifications may still be needed.