### PR TITLE
idr0011: manually add fields

### DIFF
--- a/idr0011-thorpe-Dad4/screens/Plate1-Green-B-TS-Stinger.screen
+++ b/idr0011-thorpe-Dad4/screens/Plate1-Green-B-TS-Stinger.screen
@@ -2,7 +2,7 @@
 Name = /uod/idr/filesets/idr0011-thorpe-Dad4/20150826-peter_thorpe/Stinger plates-extra images screen T34 x TS-more repeats/Plate1-Green-B-TS-Stinger
 Rows = 6
 Columns = 8
-Fields = 1
+Fields = 3
 
 [Well 0]
 Row = 0
@@ -71,6 +71,8 @@ Field_0 = /uod/idr/filesets/idr0011-thorpe-Dad4/20150826-peter_thorpe/Stinger pl
 Row = 1
 Column = 5
 Field_0 = /uod/idr/filesets/idr0011-thorpe-Dad4/20150826-peter_thorpe/Stinger plates-extra images screen T34 x TS-more repeats/Plate1-Green-B-TS-Stinger/Plate1-Green-B-27-Scene-1-P3-B6-01.czi
+Field_1 = /uod/idr/filesets/idr0011-thorpe-Dad4/20150826-peter_thorpe/Stinger plates-extra images screen T34 x TS-more repeats/Plate1-Green-B-TS-Stinger/Plate1-Green-B-27-Scene-2-P1-02.czi
+Field_2 = /uod/idr/filesets/idr0011-thorpe-Dad4/20150826-peter_thorpe/Stinger plates-extra images screen T34 x TS-more repeats/Plate1-Green-B-TS-Stinger/Plate1-Green-B-27-Scene-3-P2-03.czi
 
 [Well 14]
 Row = 1
@@ -230,4 +232,4 @@ Field_0 = /uod/idr/filesets/idr0011-thorpe-Dad4/20150826-peter_thorpe/Stinger pl
 Row = 5
 Column = 7
 Field_0 = /uod/idr/filesets/idr0011-thorpe-Dad4/20150826-peter_thorpe/Stinger plates-extra images screen T34 x TS-more repeats/Plate1-Green-B-TS-Stinger/Plate1-Green-B-36-Scene-1-P1-F8-01.czi
-
+Field_1 = /uod/idr/filesets/idr0011-thorpe-Dad4/20150826-peter_thorpe/Stinger plates-extra images screen T34 x TS-more repeats/Plate1-Green-B-TS-Stinger/Plate1-Green-B-36-Scene-3-P2-03.czi

--- a/idr0011-thorpe-Dad4/screens/Plate1-Red-B-TS-Stinger.screen
+++ b/idr0011-thorpe-Dad4/screens/Plate1-Red-B-TS-Stinger.screen
@@ -2,7 +2,7 @@
 Name = /uod/idr/filesets/idr0011-thorpe-Dad4/20150826-peter_thorpe/Stinger plates-extra images screen T34 x TS-more repeats/Plate1-Red-B-TS-Stinger
 Rows = 6
 Columns = 8
-Fields = 1
+Fields = 2
 
 [Well 0]
 Row = 0
@@ -59,6 +59,7 @@ Field_0 = /uod/idr/filesets/idr0011-thorpe-Dad4/20150826-peter_thorpe/Stinger pl
 Row = 1
 Column = 3
 Field_0 = /uod/idr/filesets/idr0011-thorpe-Dad4/20150826-peter_thorpe/Stinger plates-extra images screen T34 x TS-more repeats/Plate1-Red-B-TS-Stinger/Plate1-Red-B-18-Scene-1-P1-B4-01.czi
+Field_1 = /uod/idr/filesets/idr0011-thorpe-Dad4/20150826-peter_thorpe/Stinger plates-extra images screen T34 x TS-more repeats/Plate1-Red-B-TS-Stinger/Plate1-Red-B-18-Scene-3-P3-03.czi
 
 [Well 12]
 Row = 1
@@ -180,6 +181,7 @@ Column = 4
 Row = 4
 Column = 5
 Field_0 = /uod/idr/filesets/idr0011-thorpe-Dad4/20150826-peter_thorpe/Stinger plates-extra images screen T34 x TS-more repeats/Plate1-Red-B-TS-Stinger/Plate1-Red-B-24-Scene-1-P1-E6-01.czi
+Field_1 = /uod/idr/filesets/idr0011-thorpe-Dad4/20150826-peter_thorpe/Stinger plates-extra images screen T34 x TS-more repeats/Plate1-Red-B-TS-Stinger/Plate1-Red-B-24-Scene-3-P3-03.czi
 
 [Well 38]
 Row = 4


### PR DESCRIPTION
Five fields were not picked up by the make_screen.py script
because they lacked a well name. These were provided via email
by the author:

```
    1 Stinger plates-extra images screen T34 x TS-more repeats/Plate1-Green-B-TS-Stinger/Plate1-Green-B-27-Scene-2-P1-02.czi

This one is B6 so Plate1-Green-B-B6-02

      1 Stinger plates-extra images screen T34 x TS-more repeats/Plate1-Green-B-TS-Stinger/Plate1-Green-B-27-Scene-3-P2-03.czi

This one is B6 aswell so Plate1-Green-B-B6-03

      1 Stinger plates-extra images screen T34 x TS-more repeats/Plate1-Green-B-TS-Stinger/Plate1-Green-B-36-Scene-3-P2-03.czi

This one is F8 so Plate1-Green-B-F8-03

      1 Stinger plates-extra images screen T34 x TS-more repeats/Plate1-Red-B-TS-Stinger/Plate1-Red-B-18-Scene-3-P3-03.czi

This one is B4 so Plate1-Red-B-B4-03

      1 Stinger plates-extra images screen T34 x TS-more repeats/Plate1-Red-B-TS-Stinger/Plate1-Red-B-24-Scene-3-P3-03.czi

This one is E6 so Plate1-Red-B-E6-03

These would have not been included in the analysis because the script used the
P number as position and we excluded them but these are the strains these
images correspond to.

```