### PR TITLE
Exclude idr0027-AnalysisAllData.csv from csv checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ before_script:
 
 script:
   - find idr* -type f -name '*.screen' -print0 | xargs -0 -n1 python scripts/check_screen.py -v
-  - python scripts/travis-check.py .
+  - python scripts/travis-check.py
   - python test/all_tests.py

--- a/scripts/travis-check.py
+++ b/scripts/travis-check.py
@@ -9,13 +9,22 @@ CSVs should have unique column names and be loadable with pandas
 
 import os
 import pandas
-import sys
 import yaml
 
+# list files to exclude from checks as relative paths from the repository root
+EXCLUDE = frozenset([
+    "idr0027-dickerson-chromatin/experimentA/idr0027-AnalysisAllData.csv"
+])
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(THIS_DIR)
+EXCLUDE = [os.path.normpath(os.path.join(REPO_ROOT, _)) for _ in EXCLUDE]
 
-for root, dirs, files in os.walk(sys.argv[1]):
+
+for root, dirs, files in os.walk(REPO_ROOT):
     for f in files:
         fn = os.path.join(root, f)
+        if fn in EXCLUDE:
+            continue
 
         if fn.lower().endswith('.yml') or fn.lower().endswith('.yaml'):
             print fn


### PR DESCRIPTION
`idr0027-dickerson-chromatin/experimentA/idr0027-AnalysisAllData.csv` was failing the csv checks due to the presence of empty columns and thus breaking the Travis build. After discussing with @eleanorwilliams and @joshmoore we've decided to leave the file as it is since we're not interested in processing it. This means it has to be excluded from the checks, and that's what this PR does.

Note that now the script does not take any arguments and can be run from anywhere.