### PR TITLE
bulk.yml and plates.tsv files for idr0028 screens A, B, C and D

### DIFF
--- a/idr0028-pascualvargas-rhogtpases/screenA/idr0028-screenA-bulk.yml
+++ b/idr0028-pascualvargas-rhogtpases/screenA/idr0028-screenA-bulk.yml
@@ -1,0 +1,3 @@
+target: "Screen:name:idr0028-pascualvargas-rhogtpases/screenA"
+include: "../../bulk.yml"
+path: "idr0028-screenA-plates.tsv"

--- a/idr0028-pascualvargas-rhogtpases/screenA/idr0028-screenA-plates.tsv
+++ b/idr0028-pascualvargas-rhogtpases/screenA/idr0028-screenA-plates.tsv
@@ -1,0 +1,4 @@
+LM2_siGENOME_1A	/uod/idr/filesets/idr0028-pascualvargas-rhogtpases/20160818-original/Images/LM2_siGENOME /LM2_siGENOME_1A /MeasurementIndex.ColumbusIDX.xml
+LM2_siGENOME_1B	/uod/idr/filesets/idr0028-pascualvargas-rhogtpases/20160818-original/Images/LM2_siGENOME /LM2_siGENOME_1B/MeasurementIndex.ColumbusIDX.xml
+LM2_siGENOME_2A	/uod/idr/filesets/idr0028-pascualvargas-rhogtpases/20160818-original/Images/LM2_siGENOME /LM2_siGENOME_2A/MeasurementIndex.ColumbusIDX.xml
+LM2_siGENOME_2B	/uod/idr/filesets/idr0028-pascualvargas-rhogtpases/20160818-original/Images/LM2_siGENOME /LM2_siGENOME_2B/MeasurementIndex.ColumbusIDX.xml

--- a/idr0028-pascualvargas-rhogtpases/screenB/idr0028-screenB-bulk.yml
+++ b/idr0028-pascualvargas-rhogtpases/screenB/idr0028-screenB-bulk.yml
@@ -1,0 +1,3 @@
+target: "Screen:name:idr0028-pascualvargas-rhogtpases/screenB"
+include: "../../bulk.yml"
+path: "idr0028-screenB-plates.tsv"

--- a/idr0028-pascualvargas-rhogtpases/screenB/idr0028-screenB-plates.tsv
+++ b/idr0028-pascualvargas-rhogtpases/screenB/idr0028-screenB-plates.tsv
@@ -1,0 +1,4 @@
+LM2_ONTARGETPlus_1A	/uod/idr/filesets/idr0028-pascualvargas-rhogtpases/20160818-original/Images/LM2_ONTARGETPlus/LM2_ONTARGETPlus_1A/MeasurementIndex.ColumbusIDX.xml
+LM2_ONTARGETPlus_1B	/uod/idr/filesets/idr0028-pascualvargas-rhogtpases/20160818-original/Images/LM2_ONTARGETPlus/LM2_ONTARGETPlus_1B/MeasurementIndex.ColumbusIDX.xml
+LM2_ONTARGETPlus_2A	/uod/idr/filesets/idr0028-pascualvargas-rhogtpases/20160818-original/Images/LM2_ONTARGETPlus/LM2_ONTARGETPlus_2A/MeasurementIndex.ColumbusIDX.xml
+LM2_ONTARGETPlus_2B	/uod/idr/filesets/idr0028-pascualvargas-rhogtpases/20160818-original/Images/LM2_ONTARGETPlus/LM2_ONTARGETPlus_2B/MeasurementIndex.ColumbusIDX.xml

--- a/idr0028-pascualvargas-rhogtpases/screenC/idr0028-screenC-bulk.yml
+++ b/idr0028-pascualvargas-rhogtpases/screenC/idr0028-screenC-bulk.yml
@@ -1,0 +1,3 @@
+target: "Screen:name:idr0028-pascualvargas-rhogtpases/screenC"
+include: "../../bulk.yml"
+path: "idr0028-screenC-plates.tsv"

--- a/idr0028-pascualvargas-rhogtpases/screenC/idr0028-screenC-plates.tsv
+++ b/idr0028-pascualvargas-rhogtpases/screenC/idr0028-screenC-plates.tsv
@@ -1,0 +1,4 @@
+MDA-MB-231_siGENOME_1A	/uod/idr/filesets/idr0028-pascualvargas-rhogtpases/20160818-original/Images/MDA-MB-231_siGENOME/MDA-MB-231_siGENOME_1A/MeasurementIndex.ColumbusIDX.xml
+MDA-MB-231_siGENOME_1B	/uod/idr/filesets/idr0028-pascualvargas-rhogtpases/20160818-original/Images/MDA-MB-231_siGENOME/MDA-MB-231_siGENOME_1B/MeasurementIndex.ColumbusIDX.xml
+MDA-MB-231_siGENOME_2A	/uod/idr/filesets/idr0028-pascualvargas-rhogtpases/20160818-original/Images/MDA-MB-231_siGENOME/MDA-MB-231_siGENOME_2A/MeasurementIndex.ColumbusIDX.xml
+MDA-MB-231_siGENOME_2B	/uod/idr/filesets/idr0028-pascualvargas-rhogtpases/20160818-original/Images/MDA-MB-231_siGENOME/MDA-MB-231_siGENOME_2B/MeasurementIndex.ColumbusIDX.xml

--- a/idr0028-pascualvargas-rhogtpases/screenD/idr0028-screenD-bulk.yml
+++ b/idr0028-pascualvargas-rhogtpases/screenD/idr0028-screenD-bulk.yml
@@ -1,0 +1,3 @@
+target: "Screen:name:idr0028-pascualvargas-rhogtpases/screenD"
+include: "../../bulk.yml"
+path: "idr0028-screenD-plates.tsv"

--- a/idr0028-pascualvargas-rhogtpases/screenD/idr0028-screenD-plates.tsv
+++ b/idr0028-pascualvargas-rhogtpases/screenD/idr0028-screenD-plates.tsv
@@ -1,0 +1,4 @@
+MDA-MB-231_ONTARGETPlus_1A	/uod/idr/filesets/idr0028-pascualvargas-rhogtpases/20160818-original/Images/MDA-MB-231_GEFGAP_ONTARGETPlus/MDA-MB-231_GEFGAP_ONTARGETPlus_1A/MeasurementIndex.ColumbusIDX.xml
+MDA-MB-231_ONTARGETPlus_1B	/uod/idr/filesets/idr0028-pascualvargas-rhogtpases/20160818-original/Images/MDA-MB-231_GEFGAP_ONTARGETPlus/MDA-MB-231_GEFGAP_ONTARGETPlus_1B/MeasurementIndex.ColumbusIDX.xml
+MDA-MB-231_ONTARGETPlus_2A	/uod/idr/filesets/idr0028-pascualvargas-rhogtpases/20160818-original/Images/MDA-MB-231_GEFGAP_ONTARGETPlus/MDA-MB-231_GEFGAP_ONTARGETPlus_2A/MeasurementIndex.ColumbusIDX.xml
+MDA-MB-231_ONTARGETPlus_2B	/uod/idr/filesets/idr0028-pascualvargas-rhogtpases/20160818-original/Images/MDA-MB-231_GEFGAP_ONTARGETPlus/MDA-MB-231_GEFGAP_ONTARGETPlus_2B/MeasurementIndex.ColumbusIDX.xml


### PR DESCRIPTION
@joshmoore These 4 screens are ready for loading into idr-demo2. I'll put the annotations in a separate PR as they still need some work.

Note: the plates.tsv files have paths to files in uod/idr/filesets but the files are actually still in uod/idr/incoming.  So we either need to move the files or update the plates.tsv files before merging.