### PR TITLE
updated plates.tsv files with plate name changes in screens A, C, D a…

### DIFF
--- a/idr0011-thorpe-Dad4/screenA/idr0011-screenA-plates.tsv
+++ b/idr0011-thorpe-Dad4/screenA/idr0011-screenA-plates.tsv
@@ -1,4 +1,4 @@
-Plate1-Green-B-(46)	../screens/Plate1-Green-B-(46).screen
+Plate1-Green-B	../screens/Plate1-Green-B-(46).screen
 Plate1-Red-B	../screens/Plate1-Red-B.screen
 Plate1-Blue-B	../screens/Plate1-Blue-B.screen
 Plate1-Green-A	../screens/Plate1-Green-A.screen
@@ -19,7 +19,7 @@ Plate7-Green-B	../screens/Plate7-Green-B.screen
 Plate7-Yellow-A	../screens/Plate7-Yellow-A.screen
 Plate7-Blue-A	../screens/Plate7-Blue-A.screen
 Plate7-Green-A	../screens/Plate7-Green-A.screen
-Plate7-Red-B-used pics-(49)	../screens/Plate7-Red-B-used pics-(49).screen
+Plate7-Red-B	../screens/Plate7-Red-B-used pics-(49).screen
 Plate7-Blue-B	../screens/Plate7-Blue-B.screen
 Plate7-Red-A	../screens/Plate7-Red-A.screen
 Plate2-Green-B	../screens/Plate2-Green-B.screen
@@ -33,7 +33,7 @@ Plate2-Yellow-B	../screens/Plate2-Yellow-B.screen
 Plate9-Green-B	../screens/Plate9-Green-B.screen
 Plate9-Red-A	../screens/Plate9-Red-A.screen
 Plate9-Yellow-A	../screens/Plate9-Yellow-A.screen
-Plate9-Blue-B-(49)	../screens/Plate9-Blue-B-(49).screen
+Plate9-Blue-B	../screens/Plate9-Blue-B-(49).screen
 Plate9-Red-B	../screens/Plate9-Red-B.screen
 Plate9-Blue-A	../screens/Plate9-Blue-A.screen
 Plate9-Green-A	../screens/Plate9-Green-A.screen
@@ -45,7 +45,7 @@ Plate4-Red-A	../screens/Plate4-Red-A.screen
 Plate4-Blue-A	../screens/Plate4-Blue-A.screen
 Plate4-Red-B	../screens/Plate4-Red-B.screen
 Plate4-Yellow-B	../screens/Plate4-Yellow-B.screen
-Plate4-Yellow-A-(49)	../screens/Plate4-Yellow-A-(49).screen
+Plate4-Yellow-A	../screens/Plate4-Yellow-A-(49).screen
 Plate8-Blue-A	../screens/Plate8-Blue-A.screen
 Plate8-Yellow-B	../screens/Plate8-Yellow-B.screen
 Plate8-Blue-B	../screens/Plate8-Blue-B.screen
@@ -108,22 +108,22 @@ Plate13-Yellow-A	../screens/Plate13-Yellow-A.screen
 Plate13-Red-A	../screens/Plate13-Red-A.screen
 Plate13-Blue-B	../screens/Plate13-Blue-B.screen
 Plate13-Green-B	../screens/Plate13-Green-B.screen
-Plate13-Green-A-(47)	../screens/Plate13-Green-A-(47).screen
+Plate13-Green-A	../screens/Plate13-Green-A-(47).screen
 Plate13-Red-B	../screens/Plate13-Red-B.screen
 Plate13-Yellow-B	../screens/Plate13-Yellow-B.screen
 Plate15-Green-B	../screens/Plate15-Green-B.screen
 Plate15-Blue-A	../screens/Plate15-Blue-A.screen
 Plate15-Green-A	../screens/Plate15-Green-A.screen
-Plate15-Blue-B-(43)	../screens/Plate15-Blue-B-(43).screen
+Plate15-Blue-B	../screens/Plate15-Blue-B-(43).screen
 Plate15-Yellow-B	../screens/Plate15-Yellow-B.screen
 Plate15-Red-B	../screens/Plate15-Red-B.screen
 Plate15-Red-A	../screens/Plate15-Red-A.screen
 Plate15-Yellow-A	../screens/Plate15-Yellow-A.screen
-Plate6-Red-A-(47)	../screens/Plate6-Red-A-(47).screen
+Plate6-Red-A	../screens/Plate6-Red-A-(47).screen
 Plate6-Red-B	../screens/Plate6-Red-B.screen
 Plate6-Blue-B	../screens/Plate6-Blue-B.screen
-Plate6-Green-B-(42)	../screens/Plate6-Green-B-(42).screen
+Plate6-Green-B	../screens/Plate6-Green-B-(42).screen
 Plate6-Yellow-B	../screens/Plate6-Yellow-B.screen
 Plate6-Blue-A	../screens/Plate6-Blue-A.screen
 Plate6-Yellow-A	../screens/Plate6-Yellow-A.screen
-Plate6-Green-A-(43)	../screens/Plate6-Green-A-(43).screen
+Plate6-Green-A	../screens/Plate6-Green-A-(43).screen

--- a/idr0011-thorpe-Dad4/screenC/idr0011-screenC-plates.tsv
+++ b/idr0011-thorpe-Dad4/screenC/idr0011-screenC-plates.tsv
@@ -1,4 +1,4 @@
-Plate Stinger-Target 2-A-used pics	../screens/Plate Stinger-Target 2-A-used pics.screen
-Plate-Stinger-Target2-B-used pics	../screens/Plate-Stinger-Target2-B-used pics.screen
-Plate Stinger-Target 1-B-used pics	../screens/Plate Stinger-Target 1-B-used pics.screen
-Plate Stinger-Target 1-A-used pics	../screens/Plate Stinger-Target 1-A-used pics.screen
+Target-2-A	../screens/Plate Stinger-Target 2-A-used pics.screen
+Target-2-B	../screens/Plate-Stinger-Target2-B-used pics.screen
+Target-1-B	../screens/Plate Stinger-Target 1-B-used pics.screen
+Target-1-A	../screens/Plate Stinger-Target 1-A-used pics.screen

--- a/idr0011-thorpe-Dad4/screenD/idr0011-screenD-plates.tsv
+++ b/idr0011-thorpe-Dad4/screenD/idr0011-screenD-plates.tsv
@@ -1,1 +1,8 @@
-TS-Stinger-Target-1&2	../screens/TS-Stinger-Target-1&2.screen
+Plate1-TS-Yellow-A-Stinger	../screens/Plate1-Yellow-A-TS-Stinger.screen
+Plate1-TS-Red-A-Stinger	../screens/Plate1-Red-A-TS-Stinger.screen
+Plate1-TS-Green-B-Stinger	../screens/Plate1-Green-B-TS-Stinger.screen
+Plate1-TS-Green-A-Stinger	../screens/Plate1-Green-A-TS-Stinger.screen
+Plate1-TS-Yellow-B-Stinger	../screens/Plate1-Yellow-B-TS-Stinger.screen
+Plate1-TS-Blue-A-Stinger	../screens/Plate1-Blue-A_TS-Stinger.screen
+Plate1-TS-Red-B-Stinger	../screens/Plate1-Red-B-TS-Stinger.screen
+Plate1-TS-Blue-B-Stinger	../screens/Plate1-Blue-B-TS-Stinger.screen

--- a/idr0011-thorpe-Dad4/screenE/idr0011-screenE-plates.tsv
+++ b/idr0011-thorpe-Dad4/screenE/idr0011-screenE-plates.tsv
@@ -1,8 +1,1 @@
-Plate1-Yellow-A-TS-Stinger	../screens/Plate1-Yellow-A-TS-Stinger.screen
-Plate1-Red-A-TS-Stinger	../screens/Plate1-Red-A-TS-Stinger.screen
-Plate1-Green-B-TS-Stinger	../screens/Plate1-Green-B-TS-Stinger.screen
-Plate1-Green-A-TS-Stinger	../screens/Plate1-Green-A-TS-Stinger.screen
-Plate1-Yellow-B-TS-Stinger	../screens/Plate1-Yellow-B-TS-Stinger.screen
-Plate1-Blue-A_TS-Stinger	../screens/Plate1-Blue-A_TS-Stinger.screen
-Plate1-Red-B-TS-Stinger	../screens/Plate1-Red-B-TS-Stinger.screen
-Plate1-Blue-B-TS-Stinger	../screens/Plate1-Blue-B-TS-Stinger.screen
+Target-TS	../screens/TS-Stinger-Target-1&2.screen


### PR DESCRIPTION
…nd E, and screens D and E have been swapped

@joshmoore. 
I had to manually change by hand the plate names for screenD in demo2 after the reload.  I think the plate names in these plates.tsv files are correct.  I think i should have put in a PR for this branch and it should have been merged before you reloaded screen D. 