### PR TITLE
idr0012: fix HT47 import

### DIFF
--- a/idr0012-fuchs-cellmorph/primary/raw/screens/HT47.screen
+++ b/idr0012-fuchs-cellmorph/primary/raw/screens/HT47.screen
@@ -1402,7 +1402,6 @@ Column = 12
 AxisTypes = C
 ChannelNames = A,H,T
 Field_0 = /uod/idr/filesets/idr0012-fuchs-cellmorph/downloaded/primary/source/www.ebi.ac.uk/huber-srv/cellmorph/source/HT47/HT47H013/HT47H013_<A,H,T>1.tif
-Field_1 = /uod/idr/filesets/idr0012-fuchs-cellmorph/downloaded/primary/source/www.ebi.ac.uk/huber-srv/cellmorph/source/HT47/HT47H013/HT47H013_<A,H,T>2.tif
 
 [Well 181]
 Row = 7


### PR DESCRIPTION
A corrupt TIFF file caused the import to fail:

```
[jamoore@demo2-omero HT47]$ find . -name "*.tif" -exec file {} \; | grep -v "TIFF image data, little-endia"
./HT47H013/HT47H013_A2.tif: data
```