### PR TITLE
idr0012: fix HT10 import

### DIFF
--- a/idr0012-fuchs-cellmorph/primary/raw/screens/HT10.screen
+++ b/idr0012-fuchs-cellmorph/primary/raw/screens/HT10.screen
@@ -2161,7 +2161,6 @@ Row = 11
 Column = 14
 AxisTypes = C
 ChannelNames = A,H,T
-Field_0 = /uod/idr/filesets/idr0012-fuchs-cellmorph/downloaded/primary/source/www.ebi.ac.uk/huber-srv/cellmorph/source/HT10/HT10L015/HT10L015_<A,H,T>1.tif
 Field_1 = /uod/idr/filesets/idr0012-fuchs-cellmorph/downloaded/primary/source/www.ebi.ac.uk/huber-srv/cellmorph/source/HT10/HT10L015/HT10L015_<A,H,T>2.tif
 
 [Well 279]


### PR DESCRIPTION
This one oddly tiled image is causing issues:

```
root@e0425f331f30:/uod/idr/filesets/idr0012-fuchs-cellmorph/downloaded/primary/source/www.ebi.ac.uk/huber-srv/cellmorph/source/HT10# find . \
            -name "*.tif" -exec identify {} \; | cut -d" " -f1-8 | grep -v "TIFF 1344x1024 1344x1024+0+0 16-bit Grayscale Gray 2.761MB"
./HT10L015/HT10L015_T1.tif TIFF 670x510 670x510+0+0 16-bit sRGB 2.738MB 0.000u
```

Removing the first field from L15

Note: this can only be tested server-side so merging immediately without an `omero import -f` test.