### PR TITLE
adding renderdef.yml files which change Exp2Cam2 channel to yellow

### DIFF
--- a/idr0028-pascualvargas-rhogtpases/screenA/idr0028-screenA-renderdef.yml
+++ b/idr0028-pascualvargas-rhogtpases/screenA/idr0028-screenA-renderdef.yml
@@ -1,0 +1,13 @@
+channels:
+  1:
+    label: Exp1Cam1
+    color: "0000FF"
+  2:
+    label: Exp2Cam2
+    color: "FFFF00"
+  3:
+    label: Exp3Cam2
+    color: "00FF00"
+  4:
+    label: Exp4Cam3
+    color: "FF0000"

--- a/idr0028-pascualvargas-rhogtpases/screenB/idr0028-screenB-renderdef.yml
+++ b/idr0028-pascualvargas-rhogtpases/screenB/idr0028-screenB-renderdef.yml
@@ -1,0 +1,13 @@
+channels:
+  1:
+    label: Exp1Cam1
+    color: "0000FF"
+  2:
+    label: Exp2Cam2
+    color: "FFFF00"
+  3:
+    label: Exp3Cam2
+    color: "00FF00"
+  4:
+    label: Exp4Cam3
+    color: "FF0000"

--- a/idr0028-pascualvargas-rhogtpases/screenC/idr0028-screenC-renderdef.yml
+++ b/idr0028-pascualvargas-rhogtpases/screenC/idr0028-screenC-renderdef.yml
@@ -1,0 +1,13 @@
+channels:
+  1:
+    label: Exp1Cam1
+    color: "0000FF"
+  2:
+    label: Exp2Cam2
+    color: "FFFF00"
+  3:
+    label: Exp3Cam2
+    color: "00FF00"
+  4:
+    label: Exp4Cam3
+    color: "FF0000"

--- a/idr0028-pascualvargas-rhogtpases/screenD/idr0028-screenD-renderdef.yml
+++ b/idr0028-pascualvargas-rhogtpases/screenD/idr0028-screenD-renderdef.yml
@@ -1,0 +1,13 @@
+channels:
+  1:
+    label: Exp1Cam1
+    color: "0000FF"
+  2:
+    label: Exp2Cam2
+    color: "FFFF00"
+  3:
+    label: Exp3Cam2
+    color: "00FF00"
+  4:
+    label: Exp4Cam3
+    color: "FF0000"


### PR DESCRIPTION
this has been applied to screens A to C, and partially to D in idr0028 so we know its correct.