### PR TITLE
Add idr0027 and idr0028 to re-annotation

### DIFF
--- a/scripts/annotate/input
+++ b/scripts/annotate/input
@@ -26,3 +26,8 @@ idr0019-sero-nfkappab/screenA/idr0019-screenA-bulkmap-config.yml Screen:1203
 idr0020-barr-chtog/screenA/idr0020-screenA-bulkmap-config.yml Screen:1204
 idr0021-lawo-pericentriolarmaterial/experimentA/idr0021-experimentA-bulkmap-config.yml Project:51
 idr0023-szymborska-nuclearpore/experimentA/idr0023-experimentA-bulkmap-config.yml Project:52
+idr0027-dickerson-chromatin/experimentA/idr0027-experimentA-bulkmap-config.yml Project:151
+idr0028-pascualvargas-rhogtpases/screenA/idr0028-screenA-bulkmap-config.yml Screen:1651
+idr0028-pascualvargas-rhogtpases/screenB/idr0028-screenB-bulkmap-config.yml Screen:1652
+idr0028-pascualvargas-rhogtpases/screenC/idr0028-screenC-bulkmap-config.yml Screen:1653
+idr0028-pascualvargas-rhogtpases/screenD/idr0028-screenD-bulkmap-config.yml Screen:1654


### PR DESCRIPTION
Picked up remaining files with:

```
[jamoore@demo3-omero annotate]$ DIR=$PWD && (cd ../.. ; find idr00* -name "*bulkmap*" -exec sh -c "grep -qL {} $DIR/input || echo {}" \;) >> input

```

(rohnC as well as cellmorphB&C had to be stripped out)