### PR TITLE
Pool identifier changes

### DIFF
--- a/idr0008-rohn-actinome/screenB/idr0008-screenB-bulkmap-config.yml
+++ b/idr0008-rohn-actinome/screenB/idr0008-screenB-bulkmap-config.yml
@@ -58,12 +58,12 @@ columns:
       columns:
       - name: siRNA Identifier
         include: yes
-      - name: siRNA Pool Identifier
-        include: yes
 
   - group:
       namespace: openmicroscopy.org/mapr/sirna/supplementary
       columns:
+      - name: siRNA Pool Identifier
+        include: yes
       - name: siRNA Catalog Number
         include: yes
       - name: Sense Sequence

--- a/idr0012-fuchs-cellmorph/screenA/idr0012-screenA-bulkmap-config.yml
+++ b/idr0012-fuchs-cellmorph/screenA/idr0012-screenA-bulkmap-config.yml
@@ -48,13 +48,15 @@ columns:
       namespace: openmicroscopy.org/mapr/sirna
       columns:
       - name: siRNA Pool Identifier
-        include: yes
-      - name: siRNA Identifier
+        clientname: siRNA Identifier
         include: yes
 
   - group:
       namespace: openmicroscopy.org/mapr/sirna/supplementary
       columns:
+      - name: siRNA Identifier
+        clientname: siRNA Individual Identifiers
+        include: yes
       - name: Original GeneID Target
         include: yes
       - name: Original Gene Target
@@ -438,7 +440,7 @@ advanced:
     primary_group_keys:
     - namespace: openmicroscopy.org/mapr/sirna
       keys:
-      - siRNA Pool Identifier
+      - siRNA Identifier
     - namespace: openmicroscopy.org/mapr/gene
       keys:
       - Gene Identifier

--- a/idr0020-barr-chtog/screenA/idr0020-screenA-bulkmap-config.yml
+++ b/idr0020-barr-chtog/screenA/idr0020-screenA-bulkmap-config.yml
@@ -58,13 +58,14 @@ columns:
       namespace: openmicroscopy.org/mapr/sirna
       columns:
       - name: siRNA Pool Identifier
-        include: yes
-      - name: siRNA Sequences
+        clientname: siRNA Identifier
         include: yes
 
   - group:
       namespace: openmicroscopy.org/mapr/sirna/supplementary
       columns:
+      - name: siRNA Sequences
+        include: yes
       - name: Reagent Design Gene Annotation Build
         include: yes
 

--- a/idr0028-pascualvargas-rhogtpases/screenA/idr0028-screenA-bulkmap-config.yml
+++ b/idr0028-pascualvargas-rhogtpases/screenA/idr0028-screenA-bulkmap-config.yml
@@ -62,6 +62,7 @@ columns:
       namespace: openmicroscopy.org/mapr/sirna
       columns:
       - name: siRNA Pool Identifier
+        clientname: siRNA Identifier
         include: yes
 
   - group:
@@ -297,7 +298,7 @@ advanced:
       - Organism
     - namespace: openmicroscopy.org/mapr/sirna
       keys:
-      - siRNA Pool Identifier
+      - siRNA Identifier
     - namespace: openmicroscopy.org/mapr/gene
       keys:
       - Gene Identifier

--- a/idr0028-pascualvargas-rhogtpases/screenB/idr0028-screenB-bulkmap-config.yml
+++ b/idr0028-pascualvargas-rhogtpases/screenB/idr0028-screenB-bulkmap-config.yml
@@ -62,6 +62,7 @@ columns:
       namespace: openmicroscopy.org/mapr/sirna
       columns:
       - name: siRNA Pool Identifier
+        clientname: siRNA Identifier
         include: yes
 
   - group:
@@ -296,7 +297,7 @@ advanced:
       - Organism
     - namespace: openmicroscopy.org/mapr/sirna
       keys:
-      - siRNA Pool Identifier
+      - siRNA Identifier
     - namespace: openmicroscopy.org/mapr/gene
       keys:
       - Gene Identifier

--- a/idr0028-pascualvargas-rhogtpases/screenC/idr0028-screenC-bulkmap-config.yml
+++ b/idr0028-pascualvargas-rhogtpases/screenC/idr0028-screenC-bulkmap-config.yml
@@ -60,6 +60,7 @@ columns:
       namespace: openmicroscopy.org/mapr/sirna
       columns:
       - name: siRNA Pool Identifier
+        clientname: siRNA Identifier
         include: yes
 
   - group:
@@ -294,7 +295,7 @@ advanced:
       - Organism
     - namespace: openmicroscopy.org/mapr/sirna
       keys:
-      - siRNA Pool Identifier
+      - siRNA Identifier
     - namespace: openmicroscopy.org/mapr/gene
       keys:
       - Gene Identifier

--- a/idr0028-pascualvargas-rhogtpases/screenD/idr0028-screenD-bulkmap-config.yml
+++ b/idr0028-pascualvargas-rhogtpases/screenD/idr0028-screenD-bulkmap-config.yml
@@ -60,6 +60,7 @@ columns:
       namespace: openmicroscopy.org/mapr/sirna
       columns:
       - name: siRNA Pool Identifier
+        clientname: siRNA Identifier
         include: yes
 
   - group:
@@ -270,7 +271,7 @@ advanced:
       - Organism
     - namespace: openmicroscopy.org/mapr/sirna
       keys:
-      - siRNA Pool Identifier
+      - siRNA Identifier
     - namespace: openmicroscopy.org/mapr/gene
       keys:
       - Gene Identifier


### PR DESCRIPTION
Fixes for screens with siRNA Pool Identifiers so that the primary key is always 'siRNA Identifier'

TODO:  long term fix with both 'siRNA Identifier' and 'siRNA Pool Identifier' allowed as PK.