### PR TITLE
Pubmed fixes

### DIFF
--- a/idr0009-simpson-secretion/idr0009-study.txt
+++ b/idr0009-simpson-secretion/idr0009-study.txt
@@ -13,7 +13,7 @@ Study External URL
 Study Public Release Date																	
 																	
 # Study Publication																	
-Study PubMed ID	25373780																
+Study PubMed ID	22660414																
 Study Publication Title	Genome-wide RNAi screening identifies human proteins with a regulatory function in the early secretory pathway																
 Study Author List	"Jeremy C. Simpson, Brigitte Joggerst, Vibor Laketa, Fatima Verissimo, Cihan Cetin, Holger Erfle, Mariana G. Bexiga, Vasanth R. Singan, Jean-Karim Heriche, Beate Neumann, Alvaro Mateos, Jonathon Blake, Stephanie Bechtel, Vladimir Benes, Stefan Wiemann, Jan Ellenberg & Rainer Pepperkok"																
 Study PMC ID																	

--- a/idr0019-sero-nfkappab/idr0019-study.txt
+++ b/idr0019-sero-nfkappab/idr0019-study.txt
@@ -17,7 +17,7 @@ Study Public Release Date
 Study PubMed ID	26148352																																																																																			
 Study Publication Title	Cell shape and the microenvironment regulate nuclear translocation of NF-kappaB in breast epithelial and tumor cells																																																																																			
 Study Author List	"Sero JE, Sailem HZ, Ardy RC, Almuttaqi H, Zhang T, Bakal C"																																																																																			
-Study PMC ID																																																																																				
+Study PMC ID	PMC4380925																																																																																			
 Study DOI	http://dx.doi.org/10.15252/msb.20145644																																																																																			
 																																																																																				
 # Study Contacts																																																																																				


### PR DESCRIPTION
Fixed incorrect pubmed id in idr0009-study.txt and added a PMC ID that is now available for idr0019. 
Should be fine to merge to production as does not directly affect what is in IDR annotations. 