### PR TITLE
Git restore mtime script

### DIFF
--- a/scripts/git-restore-mtime-bare.py
+++ b/scripts/git-restore-mtime-bare.py
@@ -1,5 +1,21 @@
 #!/usr/bin/env python
 # Change mtime of files based on commit date of last change
+#
+#    Copyright (C) 2012 Rodrigo Silva (MestreLion) <linux@rodrigosilva.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
 # Bare-bones version. Current dir must be top-level of work tree.
 # Usage: git-restore-mtime-bare [pathspecs...]
 #

--- a/scripts/git-restore-mtime-bare.py
+++ b/scripts/git-restore-mtime-bare.py
@@ -23,8 +23,10 @@
 # Example: to only update only the README and files in ./doc:
 # git-restore-mtime-bare README doc
 
-import subprocess, shlex
-import sys, os.path
+import subprocess
+import shlex
+import sys
+import os.path
 
 # List files matching user pathspec, relative to current directory
 filelist = set()
@@ -51,14 +53,15 @@ for line in gitobj.stdout:
     line = line.strip()
 
     # Blank line between Date and list of files
-    if not line: continue
+    if not line:
+        continue
 
     # File line
     if line.startswith(':'):
         file = line.split('\t')[-1]
         if file in filelist:
             filelist.remove(file)
-            #print mtime, file
+            # print mtime, file
             os.utime(file, (mtime, mtime))
 
     # Date line

--- a/scripts/git-restore-mtime-bare.py
+++ b/scripts/git-restore-mtime-bare.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# Change mtime of files based on commit date of last change
+# Bare-bones version. Current dir must be top-level of work tree.
+# Usage: git-restore-mtime-bare [pathspecs...]
+#
+# By default update all files
+# Example: to only update only the README and files in ./doc:
+# git-restore-mtime-bare README doc
+
+import subprocess, shlex
+import sys, os.path
+
+# List files matching user pathspec, relative to current directory
+filelist = set()
+for path in (sys.argv[1:] or [os.path.curdir]):
+
+    # file or symlink (to file, to dir or broken - git handles the same way)
+    if os.path.isfile(path) or os.path.islink(path):
+        filelist.add(os.path.relpath(path))
+
+    # dir
+    elif os.path.isdir(path):
+        for root, subdirs, files in os.walk(path):
+            if '.git' in subdirs:
+                subdirs.remove('.git')
+
+            for file in files:
+                filelist.add(os.path.relpath(os.path.join(root, file)))
+
+# Process the log until all files are 'touched'
+mtime = 0
+gitobj = subprocess.Popen(shlex.split('git whatchanged --pretty=%at'),
+                          stdout=subprocess.PIPE)
+for line in gitobj.stdout:
+    line = line.strip()
+
+    # Blank line between Date and list of files
+    if not line: continue
+
+    # File line
+    if line.startswith(':'):
+        file = line.split('\t')[-1]
+        if file in filelist:
+            filelist.remove(file)
+            #print mtime, file
+            os.utime(file, (mtime, mtime))
+
+    # Date line
+    else:
+        mtime = long(line)
+
+    # All files done?
+    if not filelist:
+        break


### PR DESCRIPTION
Adds the https://github.com/MestreLion/git-tools/blob/962287950ece6041869004ade12dbf27438574c8/git-restore-mtime-bare script (using git filter-branch). This seems more robust than setting an arbitrary mtime on all files.

Related to https://trello.com/c/XcQRCpjh/165-timestamp-invalidates-bfmemo

To use this script run `python scripts/git-restore-mtime-bare.py` from the root of the repository