### PR TITLE
Add script to summarise current celery tasks

### DIFF
--- a/scripts/celery/get_failed.py
+++ b/scripts/celery/get_failed.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# Print out a summary of existing tasks, and failure messages
+# You will need a celeryconfig.py file in your current working directory
+# Pass a list of task IDs to stdout, e.g.
+#
+#   ./get_failed.py < taskids.txt
+
+import celery.result
+import sys
+
+
+st = {}
+fail = {}
+for line in sys.stdin:
+    for taskid in line.split():
+        r = celery.result.AsyncResult(taskid)
+        try:
+            st[r.status] += 1
+        except KeyError:
+            st[r.status] = 1
+        if r.status == 'FAILURE':
+            fail[taskid] = r
+
+print('SUMMARY')
+for k, v in st.items():
+    print('  {}: {}'.format(k, v))
+print('\nFAILURES')
+for k, v in fail.items():
+    print('  {}: {}'.format(k, v.info))


### PR DESCRIPTION
Example

Submit some calculation tasks, save the task-ids to a file:
```
python calc.py --broker BROKER_URL --out-dir /uod/idr-scratch/idr0002-screenA /uod/idr/features/idr0002-heriche-condensation/screenA/input/ --docker-img manics/pyfeatures:merge -l idr0002-A.taskids --limit 5 -- -l -t 23,178,334 -W 672 -H 512 --offset-x 336 --offset-y 256 -x 1344 -y 1024
```
```
$ ./get_failed.py < idr0002-A-1.taskids
SUMMARY
  SUCCESS: 5

FAILURES
```
```
$ ./get_failed.py < idr0002-A-2.taskids
SUMMARY
  FAILURE: 5

FAILURES
  61ca133b-6f02-4735-88ec-9229239ab247: outputpath must be an existing absolute path: /uod/idr/scratch/idr0002-screenA
  59c7a583-46b7-454c-8c42-dfd1c499450d: outputpath must be an existing absolute path: /uod/idr/scratch/idr0002-screenA
  fa5332f3-8a80-42a9-8477-7039e374ef00: outputpath must be an existing absolute path: /uod/idr/scratch/idr0002-screenA
  f0c975d3-d075-45dc-9e26-a69cb3c9ce2e: outputpath must be an existing absolute path: /uod/idr/scratch/idr0002-screenA
  60fd9298-3ddb-4dba-a998-6433e85376b6: outputpath must be an existing absolute path: /uod/idr/scratch/idr0002-screenA
```
