### PR TITLE
fixed typo in autofluorescence

### DIFF
--- a/idr0038-held-kidneylightsheet/experimentA/idr0038-experimentA-Pax2-PNArh-large-MV-renderdef.yml
+++ b/idr0038-held-kidneylightsheet/experimentA/idr0038-experimentA-Pax2-PNArh-large-MV-renderdef.yml
@@ -5,4 +5,4 @@ channels:
   2:
     label: PNA-rh
   3:
-    label: Autofluroescence
+    label: Autofluorescence

--- a/idr0038-held-kidneylightsheet/experimentA/idr0038-experimentA-Pax2-PNArh-small-MV-renderdef.yml
+++ b/idr0038-held-kidneylightsheet/experimentA/idr0038-experimentA-Pax2-PNArh-small-MV-renderdef.yml
@@ -5,4 +5,4 @@ channels:
   2:
     label: PNA-rh
   3:
-    label: Autofluroescence
+    label: Autofluorescence

--- a/idr0038-held-kidneylightsheet/experimentA/idr0038-experimentA-Wt1-FK-4-stack-renderdef.yml
+++ b/idr0038-held-kidneylightsheet/experimentA/idr0038-experimentA-Wt1-FK-4-stack-renderdef.yml
@@ -1,7 +1,7 @@
 ---
 channels:
   1:
-    label: Autofluroescence
+    label: Autofluorescence
   2:
     label: PNA-rh
   3:


### PR DESCRIPTION
3 render def yaml files in idr0038 experiment A had `Autofluroescence` instead of `Autofluorescence` in the channel names.  Fixed this typo.  Already applied the fix in idr-next(prod44). 

- idr0038-experimentA-Pax2-PNArh-large-MV-renderdef.yml
- idr0038-experimentA-Pax2-PNArh-small-MV-renderdef.yml
- idr0038-experimentA-Wt1-FK-4-stack-renderdef.yml

No testing needed, just check the files have been correctly updated.
 