### PR TITLE
Introspect top-level folder of idr-metadata from the script location

### DIFF
--- a/scripts/reannotate/README.md
+++ b/scripts/reannotate/README.md
@@ -8,5 +8,4 @@ run:
 
 Default paths:
 
-    OMERO_DIST='/home/omero/OMERO.server'
-    IDR_METADATA='/tmp/idr-metadata'
+    OMERO_DIST='/opt/omero/server/OMERO.server'

--- a/scripts/reannotate/annotate.sh
+++ b/scripts/reannotate/annotate.sh
@@ -15,7 +15,7 @@ read -sp 'Password: ' password
 set -x
 
 OMERO_DIST='/opt/omero/server/OMERO.server'
-IDR_METADATA='/tmp/idr-metadata'
+IDR_METADATA=$(dirname $(dirname $(dirname $0)))
 
 populate_ann () {
     local object=${1:-};

--- a/scripts/reannotate/bulk.sh
+++ b/scripts/reannotate/bulk.sh
@@ -15,7 +15,7 @@ read -sp 'Password: ' password
 set -x
 
 OMERO_DIST='/opt/omero/server/OMERO.server'
-IDR_METADATA='/tmp/idr-metadata'
+IDR_METADATA=$(dirname $(dirname $(dirname $0)))
 
 
 create_bulk () {

--- a/scripts/reannotate/delete.sh
+++ b/scripts/reannotate/delete.sh
@@ -15,7 +15,7 @@ read -sp 'Password: ' password
 set -x
 
 OMERO_DIST='/opt/omero/server/OMERO.server'
-IDR_METADATA='/tmp/idr-metadata'
+IDR_METADATA=$(dirname $(dirname $(dirname $0)))
 
 
 delete_ann () {


### PR DESCRIPTION
The annotation scripts currently expect the idr-metadata folder to be located at `/tmp/idr-metadata`. This assumption is not practical as soon as multiple users want to run different dataset imports or annotations on the server.

This change allows the annotation script to introspect the location of the idr-metadata folder, making it easier for anyone to use a fresh clone on an arbitrary folder to run the annotation scripts.