### PR TITLE
Study parser utility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,6 @@ before_script:
 
 script:
   - find idr* -type f -name '*.screen' -print0 | xargs -0 -n1 python scripts/check_screen.py -v
+  - find . -type f -name '*study.txt' -exec python pyidr/study_parser.py {} \;
   - python scripts/travis-check.py
   - python test/all_tests.py

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -1,0 +1,105 @@
+#! /usr/bin/env python
+
+import logging
+import os
+import re
+import sys
+
+logging.basicConfig(level=int(os.environ.get("DEBUG", logging.INFO)))
+
+
+class StudyParser():
+
+    TYPES = ["Experiment", "Screen"]
+    MANDATORY_STUDY_KEYS = {
+        'Title': 'Study Title',
+        'Description': 'Study Description',
+        'Study Type': 'Study Type',
+        'Publication Title': 'Study Publication Title',
+        'Publication Authors': 'Study Author List',
+        'License': 'Study License',
+        'License URL': 'Study License URL'
+    }
+    OPTIONAL_STUDY_KEYS = {
+        'Publication Preprint': 'Study Publication Preprint',
+        'PubMed ID': 'Study PMC ID',
+        'Publication DOI': 'Study DOI',
+    }
+    MANDATORY_COMPONENT_KEYS = {
+        'Name': 'Comment\[IDR %s Name\]',
+        'Description': '%s Description',
+        'Imaging Method': '%s Imaging Method'
+    }
+    OPTIONAL_COMPONENT_KEYS = {
+        'Data DOI': '%s Data DOI',
+        'Data Publisher': "%s Data Publisher",
+    }
+
+    def __init__(self, s):
+        self._study_file = s
+        self.parse_study()
+        self.parse_components()
+
+    def get_value(self, key, expr=".*", fail_on_missing=True, lines=None):
+        pattern = re.compile("^%s\t(%s)" % (key, expr))
+        if not lines:
+            lines = self._study_file
+        for line in lines:
+            m = pattern.match(line)
+            if m:
+                return m.group(1).rstrip()
+        if fail_on_missing:
+            raise Exception("Could not find value for key %s " % key)
+
+    def parse_study(self):
+        self.study = {}
+        for key1, key2 in self.MANDATORY_STUDY_KEYS.iteritems():
+            self.study[key1] = self.get_value(key2)
+        for key1, key2 in self.OPTIONAL_STUDY_KEYS.iteritems():
+            self.study[key1] = self.get_value(key2, fail_on_missing=False)
+
+    def parse_components(self):
+        self.components = []
+        for t in self.TYPES:
+            key = "Study %ss Number" % t
+            n = self.get_value(key, expr="\d+", fail_on_missing=False)
+            if not n:
+                continue
+            self.type = t
+            self.components = [{} for x in range(int(n))]
+            break
+
+        if not self.components:
+            raise Exception("Could not find valid study type")
+
+        for i in range(len(self.components)):
+            logging.debug("Parsing %s %g" % (self.type, i + 1))
+            self.parse_component(i)
+
+    def parse_component(self, index):
+        lines = self.get_component_lines(index + 1)
+        for key1, key2 in self.MANDATORY_COMPONENT_KEYS.iteritems():
+            self.components[index][key1] = self.get_value(key2 % self.type, lines=lines)
+
+    def get_component_lines(self, index):
+        EXPERIMENT_NUMBER_PATTERN = re.compile("^%s Number\t(\d+)" % self.type)
+        found = False
+        lines = []
+        for line in self._study_file:
+            m = EXPERIMENT_NUMBER_PATTERN.match(line)
+            if m:
+                if int(m.group(1)) == index:
+                    found = True
+                elif int(m.group(1)) != index and found:
+                    return lines
+            if found:
+                lines.append(line)
+        return lines
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 0:
+        raise Ex("Requires one study file as an input")
+    logging.info("Reading %s" % sys.argv[1])
+    with open(sys.argv[1], 'r') as f:
+        parser = StudyParser(f.readlines())

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -184,6 +184,23 @@ class StudyParser():
 
 class Object():
 
+    PUBLICATION_PAIRS = [
+        ('Publication Title', "%(Title)s"),
+        ('Publication Authors', "%(Author List)s"),
+        ('Pubmed ID', "%(PubMed ID)s "
+         "https://www.ncbi.nlm.nih.gov/pubmed/%(PubMed ID)s"),
+        ('PMC ID', "%(PMC ID)s"),
+        ('Publication DOI', "%(Study DOI)s https://dx.doi.org/%(DOI)s"),
+    ]
+    BOTTOM_PAIRS = [
+        ('License', "%(Study License)s %(Study License URL)s"),
+        ('Copyright', "%(Study Copyright)s"),
+        ('Data Publisher', "%(Study Data Publisher)s"),
+        ('Data DOI', "%(Study Data DOI)s "
+         "https://dx.doi.org/%(Study Data DOI)s"),
+        ('Annotation File', "%(Annotation File)s"),
+    ]
+
     def __init__(self, component):
         self.name = self.NAME % component
         self.description = self.generate_description(component)
@@ -194,12 +211,18 @@ class Object():
 
     def generate_annotation(self, component):
 
+        def add_key_values(d, pairs):
+            for key, formatter in pairs:
+                try:
+                    s.append(('%s' % key, formatter % d))
+                except KeyError, e:
+                    logging.debug("Missing %s" % e.message)
+
         s = []
-        for key, formatter in self.MAP_PAIRS:
-            try:
-                s.append(('%s' % key, formatter % component))
-            except KeyError, e:
-                logging.debug("Missing %s" % e.message)
+        add_key_values(component, self.TOP_PAIRS)
+        for publication in component["Publications"]:
+            add_key_values(publication, self.PUBLICATION_PAIRS)
+        add_key_values(component, self.BOTTOM_PAIRS)
         return s
 
 
@@ -209,25 +232,13 @@ class Screen(Object):
     DESCRIPTION = (
         "Publication Title\n%(Study Publication Title)s\n\n"
         "Screen Description\n%(Screen Description)s")
-    MAP_PAIRS = [
+    TOP_PAIRS = [
         ('Study Type', "%(Study Type)s"),
         ('Organism', "%(Study Organism)s"),
         ('Screen Type', "%(Screen Type)s"),
         ('Screen Technology Type', "%(Screen Technology Type)s"),
         ('Imaging Method', "%(Screen Imaging Method)s"),
-        ('Publication Title', "%(Study Publication Title)s"),
-        ('Publication Authors', "%(Study Author List)s"),
-        ('Pubmed ID', "%(Study PubMed ID)s "
-         "https://www.ncbi.nlm.nih.gov/pubmed/%(Study PubMed ID)s"),
-        ('PMC ID', "%(Study PMC ID)s"),
-        ('Publication DOI', "%(Study DOI)s https://dx.doi.org/%(Study DOI)s"),
-        ('License', "%(Study License)s %(Study License URL)s"),
-        ('Copyright', "%(Study Copyright)s"),
-        ('Data Publisher', "%(Study Data Publisher)s"),
-        ('Data DOI', "%(Study Data DOI)s "
-         "https://dx.doi.org/%(Study Data DOI)s"),
-        ('Annotation File', "%(Annotation File)s"),
-        ]
+    ]
 
 
 class Project(Object):
@@ -236,22 +247,10 @@ class Project(Object):
     DESCRIPTION = (
         "Publication Title\n%(Study Publication Title)s\n\n"
         "Experiment Description\n%(Experiment Description)s")
-    MAP_PAIRS = [
+    TOP_PAIRS = [
         ('Study Type', "%(Study Type)s"),
         ('Organism', "%(Study Organism)s"),
         ('Imaging Method', "%(Experiment Imaging Method)s"),
-        ('Publication Title', "%(Study Publication Title)s"),
-        ('Publication Authors', "%(Study Author List)s"),
-        ('Pubmed ID', "%(Study PubMed ID)s "
-         "https://www.ncbi.nlm.nih.gov/pubmed/%(Study PubMed ID)s"),
-        ('PMC ID', "%(Study PMC ID)s"),
-        ('Publication DOI', "%(Study DOI)s https://dx.doi.org/%(Study DOI)s"),
-        ('License', "%(Study License)s %(Study License URL)s"),
-        ('Copyright', "%(Study Copyright)s"),
-        ('Data Publisher', "%(Study Data Publisher)s"),
-        ('Data DOI', "%(Study Data DOI)s "
-         "https://dx.doi.org/%(Study Data DOI)s"),
-        ('Annotation File', "%(Annotation File)s"),
         ]
 
 
@@ -266,10 +265,13 @@ if __name__ == "__main__":
             obj = Project(e)
             print "name:\n%s\n" % obj.name
             print "description:\n%s\n" % obj.description
-            print "map:\n%s\n" % obj.map
+            print "map:"
+            print "\n".join(["%s\t%s" % (v[0], v[1]) for v in obj.map])
+
         screens = [c for c in p.components if c['Type'] == "Screen"]
         for s in screens:
             obj = Screen(s)
             print "name:\n%s\n" % obj.name
             print "description:\n%s\n" % obj.description
-            print "map:\n%s\n" % obj.map
+            print "map:"
+            print "\n".join(["%s\t%s" % (v[0], v[1]) for v in obj.map])

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -50,7 +50,7 @@ MANDATORY_SCREEN_KEYS = [
 OPTIONAL_SCREEN_KEYS = [
     'Screen Data DOI',
     "Screen Data Publisher",
-    'Screen Technology',
+    'Screen Technology Type',
 ]
 
 
@@ -129,12 +129,37 @@ class StudyParser():
 
 class Object():
 
+    def __init__(self, component):
+        self.name = self.NAME % component
+        self.description = self.generate_description(component)
+        self.map = self.generate_annotation(component)
+
+    def generate_description(self, component):
+        return self.DESCRIPTION % component
+
+    def generate_annotation(self, component):
+
+        s = []
+        for key, formatter in self.MAP_PAIRS:
+            try:
+                s.append(('%s' % key, formatter % component))
+            except KeyError, e:
+                logging.debug("Missing %s" % e.message)
+        return s
+
+
+class Screen(Object):
+
+    NAME = "%(Comment\[IDR Screen Name\])s"
     DESCRIPTION = (
         "Publication Title\n%(Study Publication Title)s\n\n"
-        "Study Description\n%(Study Description)s")
+        "Screen Description\n%(Screen Description)s")
     MAP_PAIRS = [
         ('Study Type', "%(Study Type)s"),
         ('Organism', "%(Study Organism)s"),
+        ('Screen Type', "%(Screen Type)s"),
+        ('Screen Technology Type', "%(Screen Technology Type)s"),
+        ('Imaging Method', "%(Screen Imaging Method)s"),
         ('Publication Title', "%(Study Publication Title)s"),
         ('Publication Authors', "%(Study Author List)s"),
         ('Pubmed ID', "%(Study PubMed ID)s "
@@ -148,45 +173,17 @@ class Object():
          "https://dx.doi.org/%(Study Data DOI)s"),
         ]
 
-    def __init__(self, study):
-        self.name = self.generate_description(study)
-        self.description = self.generate_description(study)
-        self.map = self.generate_annotation(study)
 
-    def generate_description(self, study):
-        return self.DESCRIPTION % study
+class Project(Object):
 
-    def generate_annotation(self, study):
-
-        s = []
-        for key, formatter in self.MAP_PAIRS:
-            try:
-                s.append(('%s' % key, formatter % study))
-            except KeyError, e:
-                logging.debug("Missing %s" % e.message)
-        return s
-
-
-class ScreenObject():
-
-    DESCRIPTION = (
-        "Publication Title\n%(Study Publication Title)s\n\n"
-        "Screen Description\n%(Screen Description)s")
-
-    def __init__(self, study):
-        self.name = self.generate_description(study)
-        self.description = self.generate_description(study)
-        self.map = self.generate_annotation(study)
-
-
-class Experiment():
-
+    NAME = "%(Comment\[IDR Experiment Name\])s"
     DESCRIPTION = (
         "Publication Title\n%(Study Publication Title)s\n\n"
         "Experiment Description\n%(Experiment Description)s")
     MAP_PAIRS = [
         ('Study Type', "%(Study Type)s"),
         ('Organism', "%(Study Organism)s"),
+        ('Imaging Method', "%(Experiment Imaging Method)s"),
         ('Publication Title', "%(Study Publication Title)s"),
         ('Publication Authors', "%(Study Author List)s"),
         ('Pubmed ID', "%(Study PubMed ID)s "
@@ -199,24 +196,6 @@ class Experiment():
         ('Data DOI', "%(Study Data DOI)s "
          "https://dx.doi.org/%(Study Data DOI)s"),
         ]
-
-    def __init__(self, experiment):
-        self.name =  "%(Comment\[IDR Experiment Name\])s" % experiment
-        self.description = self.generate_description(experiment)
-        self.map = self.generate_annotation(experiment)
-
-    def generate_description(self, experiment):
-        return self.DESCRIPTION % experiment
-
-    def generate_annotation(self, experiment):
-
-        s = []
-        for key, formatter in self.MAP_PAIRS:
-            try:
-                s.append(('%s' % key, formatter % experiment))
-            except KeyError, e:
-                logging.debug("Missing %s" % e.message)
-        return s
 
 
 if __name__ == "__main__":
@@ -227,7 +206,13 @@ if __name__ == "__main__":
         parser = StudyParser(f.readlines())
     if len(sys.argv) == 3 and sys.argv[2] == '--report':
         for e in parser.experiments:
-            obj = Experiment(e)
+            logging.info("Generating %s" % sys.argv[1])
+            obj = Project(e)
+            print "name:\n%s\n" % obj.name
+            print "description:\n%s\n" % obj.description
+            print "map:\n%s\n" % obj.map
+        for s in parser.screens:
+            obj = Screen(s)
             print "name:\n%s\n" % obj.name
             print "description:\n%s\n" % obj.description
             print "map:\n%s\n" % obj.map

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -190,7 +190,7 @@ class Object():
         ('Pubmed ID', "%(PubMed ID)s "
          "https://www.ncbi.nlm.nih.gov/pubmed/%(PubMed ID)s"),
         ('PMC ID', "%(PMC ID)s"),
-        ('Publication DOI', "%(Study DOI)s https://dx.doi.org/%(DOI)s"),
+        ('Publication DOI', "%(DOI)s https://dx.doi.org/%(DOI)s"),
     ]
     BOTTOM_PAIRS = [
         ('License', "%(Study License)s %(Study License URL)s"),

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -15,9 +15,9 @@ MANDATORY_STUDY_KEYS = [
     'Study Type',
     'Study Publication Title',
     'Study Author List',
+    'Study Organism',
 ]
 OPTIONAL_STUDY_KEYS = [
-    'Study Organism',
     'Study Publication Preprint',
     'Study PubMed ID',
     'Study PMC ID',
@@ -34,6 +34,7 @@ MANDATORY_EXPERIMENT_KEYS = [
     'Comment\[IDR Experiment Name\]',
     'Experiment Description',
     'Experiment Imaging Method',
+    'Experiment Number'
 ]
 OPTIONAL_EXPERIMENT_KEYS = [
     'Experiment Data DOI',
@@ -65,6 +66,8 @@ class StudyParser():
             self.parse_experiments()
         if 'Study Screens Number' in self.study:
             self.parse_screens()
+        if not self.experiments and not self.screens:
+            raise Exception("Need to define at least one screen or experiment")
 
     def get_value(self, key, expr=".*", fail_on_missing=True, lines=None):
         pattern = re.compile("^%s\t(%s)" % (key, expr))

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -7,38 +7,64 @@ import sys
 
 logging.basicConfig(level=int(os.environ.get("DEBUG", logging.INFO)))
 
+TYPES = ["Experiment", "Screen"]
+MANDATORY_STUDY_KEYS = [
+    'Comment\[IDR Study Accession\]',
+    'Study Title',
+    'Study Description',
+    'Study Type',
+    'Study Publication Title',
+    'Study Author List',
+]
+OPTIONAL_STUDY_KEYS = [
+    'Study Organism',
+    'Study Publication Preprint',
+    'Study PubMed ID',
+    'Study PMC ID',
+    'Study DOI',
+    'Study Copyright',
+    'Study License',
+    'Study License URL',
+    'Study Data Publisher',
+    'Study Data DOI',
+    'Study Experiments Number',
+    'Study Screens Number',
+]
+MANDATORY_EXPERIMENT_KEYS = [
+    'Comment\[IDR Experiment Name\]',
+    'Experiment Description',
+    'Experiment Imaging Method',
+]
+OPTIONAL_EXPERIMENT_KEYS = [
+    'Experiment Data DOI',
+    "Experiment Data Publisher",
+]
+
+MANDATORY_SCREEN_KEYS = [
+    'Comment\[IDR Screen Name\]',
+    'Screen Description',
+    'Screen Imaging Method',
+    'Screen Number',
+    'Screen Type',
+]
+OPTIONAL_SCREEN_KEYS = [
+    'Screen Data DOI',
+    "Screen Data Publisher",
+    'Screen Technology',
+]
+
 
 class StudyParser():
 
-    TYPES = ["Experiment", "Screen"]
-    MANDATORY_STUDY_KEYS = {
-        'Title': 'Study Title',
-        'Description': 'Study Description',
-        'Study Type': 'Study Type',
-        'Publication Title': 'Study Publication Title',
-        'Publication Authors': 'Study Author List',
-        'License': 'Study License',
-        'License URL': 'Study License URL'
-    }
-    OPTIONAL_STUDY_KEYS = {
-        'Publication Preprint': 'Study Publication Preprint',
-        'PubMed ID': 'Study PMC ID',
-        'Publication DOI': 'Study DOI',
-    }
-    MANDATORY_COMPONENT_KEYS = {
-        'Name': 'Comment\[IDR %s Name\]',
-        'Description': '%s Description',
-        'Imaging Method': '%s Imaging Method'
-    }
-    OPTIONAL_COMPONENT_KEYS = {
-        'Data DOI': '%s Data DOI',
-        'Data Publisher': "%s Data Publisher",
-    }
-
     def __init__(self, s):
         self._study_file = s
-        self.parse_study()
-        self.parse_components()
+        self.study = self.parse(MANDATORY_STUDY_KEYS, OPTIONAL_STUDY_KEYS)
+        self.experiments = []
+        self.screens = []
+        if 'Study Experiments Number' in self.study:
+            self.parse_experiments()
+        if 'Study Screens Number' in self.study:
+            self.parse_screens()
 
     def get_value(self, key, expr=".*", fail_on_missing=True, lines=None):
         pattern = re.compile("^%s\t(%s)" % (key, expr))
@@ -51,43 +77,44 @@ class StudyParser():
         if fail_on_missing:
             raise Exception("Could not find value for key %s " % key)
 
-    def parse_study(self):
-        self.study = {}
-        for key1, key2 in self.MANDATORY_STUDY_KEYS.iteritems():
-            self.study[key1] = self.get_value(key2)
-        for key1, key2 in self.OPTIONAL_STUDY_KEYS.iteritems():
-            self.study[key1] = self.get_value(key2, fail_on_missing=False)
+    def parse(self, mandatory_keys, optional_keys, lines=None):
+        d = {}
+        for key in mandatory_keys:
+            d[key] = self.get_value(key, lines=lines)
+        for key in optional_keys:
+            value = self.get_value(key, fail_on_missing=False, lines=lines)
+            if value:
+                d[key] = value
+        return d
 
-    def parse_components(self):
-        self.components = []
-        for t in self.TYPES:
-            key = "Study %ss Number" % t
-            n = self.get_value(key, expr="\d+", fail_on_missing=False)
-            if not n:
-                continue
-            self.type = t
-            self.components = [{} for x in range(int(n))]
-            break
+    def parse_experiments(self):
+        n = int(self.study['Study Experiments Number'])
+        self.experiments = [{}] * n
 
-        if not self.components:
-            raise Exception("Could not find valid study type")
+        for i in range(len(self.experiments)):
+            logging.debug("Parsing experiment %g" % (i + 1))
+            self.experiments[i] = self.parse(
+                MANDATORY_EXPERIMENT_KEYS, OPTIONAL_EXPERIMENT_KEYS,
+                lines=self.get_lines(i + 1, "Experiment"))
+            self.experiments[i].update(self.study)
 
-        for i in range(len(self.components)):
-            logging.debug("Parsing %s %g" % (self.type, i + 1))
-            self.parse_component(i)
+    def parse_screens(self):
+        n = int(self.study['Study Screens Number'])
+        self.screens = [{}] * n
 
-    def parse_component(self, index):
-        lines = self.get_component_lines(index + 1)
-        for key1, key2 in self.MANDATORY_COMPONENT_KEYS.iteritems():
-            self.components[index][key1] = self.get_value(
-                key2 % self.type, lines=lines)
+        for i in range(len(self.screens)):
+            logging.debug("Parsing screen %g" % (i + 1))
+            self.screens[i] = self.parse(
+                MANDATORY_SCREEN_KEYS, OPTIONAL_SCREEN_KEYS,
+                lines=self.get_lines(i + 1, "Screen"))
+            self.screens[i].update(self.study)
 
-    def get_component_lines(self, index):
-        EXPERIMENT_NUMBER_PATTERN = re.compile("^%s Number\t(\d+)" % self.type)
+    def get_lines(self, index, component_type):
+        PATTERN = re.compile("^%s Number\t(\d+)" % component_type)
         found = False
         lines = []
         for line in self._study_file:
-            m = EXPERIMENT_NUMBER_PATTERN.match(line)
+            m = PATTERN.match(line)
             if m:
                 if int(m.group(1)) == index:
                     found = True
@@ -98,34 +125,107 @@ class StudyParser():
         return lines
 
 
-class StudyObject():
+class Object():
 
-    def __init__(self, parser):
-        self.description = self.generate_description(parser)
-        self.map = self.generate_annotation(parser)
+    DESCRIPTION = (
+        "Publication Title\n%(Study Publication Title)s\n\n"
+        "Study Description\n%(Study Description)s")
+    MAP_PAIRS = [
+        ('Study Type', "%(Study Type)s"),
+        ('Organism', "%(Study Organism)s"),
+        ('Publication Title', "%(Study Publication Title)s"),
+        ('Publication Authors', "%(Study Author List)s"),
+        ('Pubmed ID', "%(Study PubMed ID)s "
+         "https://www.ncbi.nlm.nih.gov/pubmed/%(Study PubMed ID)s"),
+        ('PMC ID', "%(Study PMC ID)s"),
+        ('Publication DOI', "%(Study DOI)s https://dx.doi.org/%(Study DOI)s"),
+        ('License', "%(Study License)s %(Study License URL)s"),
+        ('Copyright', "%(Study Copyright)s"),
+        ('Data Publisher', "%(Study Data Publisher)s"),
+        ('Data DOI', "%(Study Data DOI)s "
+         "https://dx.doi.org/%(Study Data DOI)s"),
+        ]
 
-    def generate_description(self, parser):
-        return "Publication Title\n%s\n\nStudy Description\n%s" % (
-             parser.study['Publication Title'],
-             parser.study['Description'])
+    def __init__(self, study):
+        self.name = self.generate_description(study)
+        self.description = self.generate_description(study)
+        self.map = self.generate_annotation(study)
 
-    def generate_annotation(self, parser):
-        KEYS = ['Study Type', 'Publication Title', 'Publication Authors',
-                'PubMed ID', 'Publication DOI', 'Publication Preprint',
-                'License', 'Copyright']
-        s = ''
-        for key in KEYS:
-            s += '(%s,%s)' % (key, parser.study.get(key, 'None'))
+    def generate_description(self, study):
+        return self.DESCRIPTION % study
+
+    def generate_annotation(self, study):
+
+        s = []
+        for key, formatter in self.MAP_PAIRS:
+            try:
+                s.append(('%s' % key, formatter % study))
+            except KeyError, e:
+                logging.debug("Missing %s" % e.message)
+        return s
+
+
+class ScreenObject():
+
+    DESCRIPTION = (
+        "Publication Title\n%(Study Publication Title)s\n\n"
+        "Screen Description\n%(Screen Description)s")
+
+    def __init__(self, study):
+        self.name = self.generate_description(study)
+        self.description = self.generate_description(study)
+        self.map = self.generate_annotation(study)
+
+
+class Experiment():
+
+    DESCRIPTION = (
+        "Publication Title\n%(Study Publication Title)s\n\n"
+        "Experiment Description\n%(Experiment Description)s")
+    MAP_PAIRS = [
+        ('Study Type', "%(Study Type)s"),
+        ('Organism', "%(Study Organism)s"),
+        ('Publication Title', "%(Study Publication Title)s"),
+        ('Publication Authors', "%(Study Author List)s"),
+        ('Pubmed ID', "%(Study PubMed ID)s "
+         "https://www.ncbi.nlm.nih.gov/pubmed/%(Study PubMed ID)s"),
+        ('PMC ID', "%(Study PMC ID)s"),
+        ('Publication DOI', "%(Study DOI)s https://dx.doi.org/%(Study DOI)s"),
+        ('License', "%(Study License)s %(Study License URL)s"),
+        ('Copyright', "%(Study Copyright)s"),
+        ('Data Publisher', "%(Study Data Publisher)s"),
+        ('Data DOI', "%(Study Data DOI)s "
+         "https://dx.doi.org/%(Study Data DOI)s"),
+        ]
+
+    def __init__(self, experiment):
+        self.name =  "%(Comment\[IDR Experiment Name\])s" % experiment
+        self.description = self.generate_description(experiment)
+        self.map = self.generate_annotation(experiment)
+
+    def generate_description(self, experiment):
+        return self.DESCRIPTION % experiment
+
+    def generate_annotation(self, experiment):
+
+        s = []
+        for key, formatter in self.MAP_PAIRS:
+            try:
+                s.append(('%s' % key, formatter % experiment))
+            except KeyError, e:
+                logging.debug("Missing %s" % e.message)
         return s
 
 
 if __name__ == "__main__":
     if len(sys.argv) == 0:
         raise Exception("Requires one study file as an input")
-    logging.info("Reading %s" % sys.argv[1])
+    logging.info("Parsing %s" % sys.argv[1])
     with open(sys.argv[1], 'r') as f:
         parser = StudyParser(f.readlines())
     if len(sys.argv) == 3 and sys.argv[2] == '--report':
-        s = StudyObject(parser)
-        print "description:\n%s\n" % s.description
-        print "attributes:\n%s\n" % s.map
+        for e in parser.experiments:
+            obj = Experiment(e)
+            print "name:\n%s\n" % obj.name
+            print "description:\n%s\n" % obj.description
+            print "map:\n%s\n" % obj.map

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -98,9 +98,34 @@ class StudyParser():
         return lines
 
 
+class StudyObject():
+
+    def __init__(self, parser):
+        self.description = self.generate_description(parser)
+        self.map = self.generate_annotation(parser)
+
+    def generate_description(self, parser):
+        return "Publication Title\n%s\n\nStudyDescription\n%s" % (
+             parser.study['Publication Title'],
+             parser.study['Description'])
+
+    def generate_annotation(self, parser):
+        KEYS = ['Study Type', 'Publication Title', 'Publication Authors',
+                'PubMed ID', 'Publication DOI', 'Publication Preprint',
+                'License', 'Copyright']
+        s = ''
+        for key in KEYS:
+            s += '(%s,%s)' % (key, parser.study.get(key, 'None'))
+        return s
+
+
 if __name__ == "__main__":
     if len(sys.argv) == 0:
         raise Exception("Requires one study file as an input")
     logging.info("Reading %s" % sys.argv[1])
     with open(sys.argv[1], 'r') as f:
         parser = StudyParser(f.readlines())
+    if len(sys.argv) == 3 and sys.argv[2] == '--report':
+        s = StudyObject(parser)
+        print "description:\n%s\n" % s.description
+        print "attributes:\n%s\n" % s.map

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -105,7 +105,7 @@ class StudyObject():
         self.map = self.generate_annotation(parser)
 
     def generate_description(self, parser):
-        return "Publication Title\n%s\n\nStudyDescription\n%s" % (
+        return "Publication Title\n%s\n\nStudy Description\n%s" % (
              parser.study['Publication Title'],
              parser.study['Description'])
 

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -79,7 +79,8 @@ class StudyParser():
     def parse_component(self, index):
         lines = self.get_component_lines(index + 1)
         for key1, key2 in self.MANDATORY_COMPONENT_KEYS.iteritems():
-            self.components[index][key1] = self.get_value(key2 % self.type, lines=lines)
+            self.components[index][key1] = self.get_value(
+                key2 % self.type, lines=lines)
 
     def get_component_lines(self, index):
         EXPERIMENT_NUMBER_PATTERN = re.compile("^%s Number\t(\d+)" % self.type)
@@ -99,7 +100,7 @@ class StudyParser():
 
 if __name__ == "__main__":
     if len(sys.argv) == 0:
-        raise Ex("Requires one study file as an input")
+        raise Exception("Requires one study file as an input")
     logging.info("Reading %s" % sys.argv[1])
     with open(sys.argv[1], 'r') as f:
         parser = StudyParser(f.readlines())

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -122,6 +122,8 @@ class StudyParser():
                     return lines
             if found:
                 lines.append(line)
+        if not lines:
+            raise Exception("Could not find %s %g" % (component_type, index))
         return lines
 
 


### PR DESCRIPTION
This PR creates a utility class to parse the content of the version 1 of IDR study files (INI file based).

- for each study file, the mandatory and optional fields are read depending on the study type (experiment vs screen). Errors are thrown on missing mandatory fields
- the metadata block for each study component (experiment, screen) is detected and parsed
- the publications are turned into a list with `Title` and `Authors` as the mandatory fields and `Preprint`, `DOI`, `PMCID`, `PubMed ID` as the optional fields.
- some validation is performed on some fields
- a class is created to generate the attribute of OMERO objects corresponding to the study/experiments/screens (description, name, map annotation key/value pairs)

## Testing

- run `python pyidr/study_parser.py <idrXXX-YYY-ZZZ>/<idrXXX-study.txt>`. This should throw an exception if some invalidities are found
- run `python pyidr/study_parser.py <idrXXX-YYY-ZZZ>/<idrXXX-study.txt> --report`. This should turn the parsed content into fields matching what is on OMERO
- review the output of Travis which should run the parser in non-failing mode

## Next steps

- update the various studies failing the parsing 
- update the script logic and Travis to fail on invalid study metadata
- consume the object classes to assert the correctness of the annotations on IDR (e.g. `python pyidr/study_parser.py --check`)

/cc @pwalczysko @dominikl 