### PR TITLE
Add support for multiple values separated by tab

### DIFF
--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -254,7 +254,12 @@ class Object():
         def add_key_values(d, pairs):
             for key, formatter in pairs:
                 try:
-                    s.append(('%s' % key, formatter % d))
+                    value = formatter % d
+                    if '\t' in value:
+                        for v in value.split('\t'):
+                            s.append(('%s' % key, v))
+                    else:
+                        s.append(('%s' % key, value))
                 except KeyError, e:
                     logging.debug("Missing %s" % e.message)
 

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -255,11 +255,8 @@ class Object():
             for key, formatter in pairs:
                 try:
                     value = formatter % d
-                    if '\t' in value:
-                        for v in value.split('\t'):
-                            s.append(('%s' % key, v))
-                    else:
-                        s.append(('%s' % key, value))
+                    for v in value.split('\t'):
+                        s.append(('%s' % key, v))
                 except KeyError, e:
                     logging.debug("Missing %s" % e.message)
 


### PR DESCRIPTION
Adds support for multiple, tab separated values for the key-value pair annotations to the study_parser.

See https://github.com/IDR/idr0041-cai-mitoticatlas/blob/master/idr0041-study.txt#L53 

/cc @sbesson 