### PR TITLE
Add script to create datasets before image import

### DIFF
--- a/scripts/create_datasets.sh
+++ b/scripts/create_datasets.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+if [ "$#" -ne 2 ]
+then
+    echo "
+This script iterates over the filePaths.tsv, creates all
+Datasets and links them to the Project.
+
+Usage:
+./create_datasets.sh [PROJECT ID] [PATH TO filePaths.tsv]
+"
+    exit 1
+fi
+
+projectId=$1
+filePaths=$2
+
+# The path to the omero CLI
+omero=/opt/omero/server/OMERO.server/bin/omero
+
+#######################
+
+# Create a session
+$omero login
+
+# Create a list of dataset names
+datasets=`cat $filePaths | cut -f1 | cut -d ':' -f3 | uniq`
+
+IFS=$'\n'
+for dataset in $datasets
+do
+  datasetId=`$omero hql --ids-only --limit 1 --style plain "select d from Dataset d where d.name='$dataset'"`
+  if [ -z $datasetId ]; then
+    datasetId=`$omero obj new Dataset name=$dataset`
+    echo "Created dataset $dataset , $datasetId"
+  else
+    datasetId=`echo $datasetId | cut -d ',' -f2 | cut -d ':' -f2`
+    proj=`$omero hql --ids-only --limit 1 --style plain "select l.parent from ProjectDatasetLink l where l.child.id='$datasetId'"`
+    proj=`echo $proj | cut -d ',' -f2 | cut -d ':' -f2`
+    if [ "$proj" != "$projectId" ]
+    then
+      datasetId=`$omero obj new Dataset name=$dataset`
+      echo "Created dataset $dataset , $datasetId"
+      echo "Note: At least one dataset with the same name already exists in another Project"
+    else
+      echo "Dataset $dataset exists, DatasetI:$datasetId"
+      continue
+    fi
+  fi
+
+  linkId=`$omero hql --ids-only --limit 1 --style plain "select l from ProjectDatasetLink l join l.child as ds where ds.name='$dataset' and l.parent.id='$projectId'"`
+  if [ -z $linkId ]; then
+    linkId=`$omero obj new ProjectDatasetLink parent=ProjectI:$projectId child=$datasetId`
+    echo "Created ProjectDatasetLink ProjectI:$projectId $datasetId, $linkId"
+  fi
+done

--- a/scripts/create_datasets.sh
+++ b/scripts/create_datasets.sh
@@ -24,7 +24,7 @@ omero=/opt/omero/server/OMERO.server/bin/omero
 $omero login
 
 # Create a list of dataset names
-datasets=`cat $filePaths | cut -f1 | cut -d ':' -f3 | uniq`
+datasets=`cut -f1 $filePaths | cut -d ':' -f3 | sort -u`
 
 IFS=$'\n'
 for dataset in $datasets


### PR DESCRIPTION
This PR adds a bash script which creates and links all datasets mentioned in a filepath.tsv using the OMERO.cli. 

The datasets should be created prior to the image import in general, because:
- If they don't exist, they will be created on the root level and have to be moved manually into the respective project (which in case of HPA for example isn't doable).
- If a dataset with the same already exists in another project, the images will be imported into that dataset, which is obviously wrong. If however the dataset is created before the image import, the images will get imported into the correct one (because the import will pick the most recent one, afaik).

Based on: https://github.com/IDR/idr0043-uhlen-humanproteinatlas/blob/master/scripts/import/create_datasets.sh which I'll remove, if this PR gets merged.