### PR TITLE
Expand README to cover GitHub study repositories structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [![Published screens](https://img.shields.io/badge/dynamic/json.svg?label=Published%20&url=http%3A%2F%2Fidr.openmicroscopy.org%2Fapi%2Fv0%2Fm%2Fscreens%2F%3Flimit%3D0&query=meta.totalCount&colorB=blue&suffix=%20high%20content%20screens)](https://idr.openmicroscopy.org) [![Published experiments](https://img.shields.io/badge/dynamic/json.svg?label=Published%20&url=http%3A%2F%2Fidr.openmicroscopy.org%2Fapi%2Fv0%2Fm%2Fprojects%2F%3Flimit%3D0&query=meta.totalCount&colorB=blue&suffix=%20experiments)](https://idr.openmicroscopy.org)
 
-All metadata associated with published studies in IDR is managed
+All metadata associated with published studies in IDR is managed.
 
 ## Study name 
 
 After acceptance, IDR studies must be named as `idr<NNNN>-<name>-<description>`
 where `idr<NNNN>` is the accession number of the study using an incremental
-four digits integer, `<author>` is the name of one of the authors associated
+four digits integer, `<name>` is the name of one of the authors associated
 with the publication, usually the first author, and `<description>` is a short
 description of the study. The name should be lowercase.
 
@@ -20,23 +20,25 @@ registered in the top-level idr-metadata repository.
 Study repository contain all curated metadata files associated with a study.
 The structure of each study repository should use the following layout:
 
-    .travis.yml         # Travis CI configuration file, used for validation
-    bulk.yml            # Optional import configuration file for multi-experiment or multi-screen studies
+    .travis.yml         # Travis CI configuration file, used for validation (recommended)
+    bulk.yml            # Optional import configuration file for multi-experiment or multi-screen studies (optional)
     experimentA/        # Curated metadata for experimentA if applicable
-        idrNNNN-experimentA-annotation.csv       # Curated image annotations
-        idrNNNN-experimentA-bulk.yml             # Configuration file for import
-        idrNNNN-experimentA-bulkmap-config.yml   # Configuration file for annotation
-        idrNNNN-experimentA-filePaths.tsv        # Files/folder to be imported
+        idrNNNN-experimentA-annotation.csv       # Curated annotation file (mandatory)
+        idrNNNN-experimentA-assays.txt           # Original annotation file (recommended)
+        idrNNNN-experimentA-bulk.yml             # Configuration file for import (mandatory)
+        idrNNNN-experimentA-bulkmap-config.yml   # Configuration file for annotation (mandatory)
+        idrNNNN-experimentA-filePaths.tsv        # Files/folder to be imported (mandatory)
     experimentB/        # Curated metadata for experimentA if applicable
        ...
-    idrNNNN-study.txt.  # Top-level metadata file describing the study
+    idrNNNN-study.txt.  # Top-level metadata file describing the study (mandatory)
     screenA/            # Curated metadata for screenA if applicable
-        idrNNNN-screenA-annotation.csv           # Curated well annotations
-        idrNNNN-screenA-bulk.yml                 # Configuration file for import
-        idrNNNN-screenA-bulkmap-config.yml       # Configuration file for annotation
-        idrNNNN-screenA-plates.tsv               # Plates to be imported
+        idrNNNN-screenA-annotation.csv           # Curated annotation file (mandatory)
+        idrNNNN-screenA-bulk.yml                 # Configuration file for import (mandatory)
+        idrNNNN-screenA-bulkmap-config.yml       # Configuration file for annotation (mandatory)
+        idrNNNN-screenA-library.txt              # Original annotation file (recommended)
+        idrNNNN-screenA-plates.tsv               # Plates to be imported (mandatory)
     screenB/            # Curated metadata for screenA if applicable
        ...
-    scripts/            # Folder containing custom scripts associated with the study
-    README.md           # Optional top-level readme
+    scripts/            # Folder containing custom scripts associated with the study (optional)
+    README.md           # Optional top-level readme (optional)
     requirements.txt    # Python dependencies used for Travis or scripts

--- a/README.md
+++ b/README.md
@@ -16,11 +16,17 @@ should be lowercase.
 
 ## Study repository 
 
-For each new IDR study, a repository must be created on GitHub under the [IDR](http://github.com/IDR/) organization using the study name as defined above. When ready for publication in the IDR, the study repository must be
+For each new study, a repository must be created on GitHub under the
+[IDR](http://github.com/IDR/) organization using the study name as defined
+above. When ready for publication in the IDR, the study repository must be
 registered in the top-level idr-metadata repository as a submodule.
 
-A study repository contains all curated metadata files associated with a study.
-The structure of each study repository should use the following layout:
+A study repository contains all original and curated metadata files associated
+with a study. The
+[idr0000-lastname-example](https://github.com/IDR/idr0000-lastname-example)
+repository contains the templates that should be used by submitters
+when sending original metdata files for screen or experiment studies. The
+structure of each study repository should use the following layout:
 
     .travis.yml                                  # Travis CI configuration file, used for validation (mandatory)
     bulk.yml                                     # Import configuration file for multi-experiment or multi-screen studies (optional)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ After acceptance, IDR studies must be named as `idr<NNNN>-<name>-<description>`
 where `idr<NNNN>` is the accession number of the study using an incremental
 four digits integer, `<name>` is the name of one of the authors associated
 with the publication, usually the first author, and `<description>` is a short
-description of the study. The name should be lowercase.
+description of the study or the name of the project/consortium. The study name
+should be lowercase.
 
 ## Study repository 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![Published screens](https://img.shields.io/badge/dynamic/json.svg?label=Published%20&url=http%3A%2F%2Fidr.openmicroscopy.org%2Fapi%2Fv0%2Fm%2Fscreens%2F%3Flimit%3D0&query=meta.totalCount&colorB=blue&suffix=%20high%20content%20screens)](https://idr.openmicroscopy.org) [![Published experiments](https://img.shields.io/badge/dynamic/json.svg?label=Published%20&url=http%3A%2F%2Fidr.openmicroscopy.org%2Fapi%2Fv0%2Fm%2Fprojects%2F%3Flimit%3D0&query=meta.totalCount&colorB=blue&suffix=%20experiments)](https://idr.openmicroscopy.org)
 
-All metadata associated with published studies in IDR is managed.
+All metadata associated with published studies in IDR is managed in this
+repository.
 
 ## Study name 
 
@@ -15,12 +16,12 @@ description of the study. The name should be lowercase.
 ## Study repository 
 
 For each new IDR study, a repository must be created on GitHub under the [IDR](http://github.com/IDR/) organization using the study name as defined above. When ready for publication in the IDR, the study repository must be
-registered in the top-level idr-metadata repository.
+registered in the top-level idr-metadata repository as a submodule.
 
-Study repository contain all curated metadata files associated with a study.
+A study repository contains all curated metadata files associated with a study.
 The structure of each study repository should use the following layout:
 
-    .travis.yml                                  # Travis CI configuration file, used for validation (recommended)
+    .travis.yml                                  # Travis CI configuration file, used for validation (mandatory)
     bulk.yml                                     # Import configuration file for multi-experiment or multi-screen studies (optional)
     experimentA/                                 # Curated metadata for experimentA (if applicable)
         idrNNNN-experimentA-annotation.csv       # Curated annotation file (mandatory)
@@ -28,7 +29,7 @@ The structure of each study repository should use the following layout:
         idrNNNN-experimentA-bulk.yml             # Configuration file for import (mandatory)
         idrNNNN-experimentA-bulkmap-config.yml   # Configuration file for annotation (mandatory)
         idrNNNN-experimentA-filePaths.tsv        # Files/folder to be imported (mandatory)
-    experimentB/                                 # Curated metadata for experimentA (if applicable)
+    experimentB/                                 # Curated metadata for experimentB (if applicable)
        ...
     idrNNNN-study.txt                            # Top-level metadata file describing the study (mandatory)
     screenA/                                     # Curated metadata for screenA if applicable
@@ -37,7 +38,7 @@ The structure of each study repository should use the following layout:
         idrNNNN-screenA-bulkmap-config.yml       # Configuration file for annotation (mandatory)
         idrNNNN-screenA-library.txt              # Original annotation file (recommended)
         idrNNNN-screenA-plates.tsv               # Plates to be imported (mandatory)
-    screenB/                                     # Curated metadata for screenA if applicable
+    screenB/                                     # Curated metadata for screenB if applicable
        ...
     scripts/                                     # Folder containing custom scripts associated with the study (optional)
     README.md                                    # Optional top-level readme (optional)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A study repository contains all original and curated metadata files associated
 with a study. The
 [idr0000-lastname-example](https://github.com/IDR/idr0000-lastname-example)
 repository contains the templates that should be used by submitters
-when sending original metdata files for screen or experiment studies. The
+when sending original metadata files for screen or experiment studies. The
 structure of each study repository should use the following layout:
 
     .travis.yml                                  # Travis CI configuration file, used for validation (mandatory)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,42 @@
-# IDR metadata
+# IDR studies
 
 [![Published screens](https://img.shields.io/badge/dynamic/json.svg?label=Published%20&url=http%3A%2F%2Fidr.openmicroscopy.org%2Fapi%2Fv0%2Fm%2Fscreens%2F%3Flimit%3D0&query=meta.totalCount&colorB=blue&suffix=%20high%20content%20screens)](https://idr.openmicroscopy.org) [![Published experiments](https://img.shields.io/badge/dynamic/json.svg?label=Published%20&url=http%3A%2F%2Fidr.openmicroscopy.org%2Fapi%2Fv0%2Fm%2Fprojects%2F%3Flimit%3D0&query=meta.totalCount&colorB=blue&suffix=%20experiments)](https://idr.openmicroscopy.org)
+
+All metadata associated with published studies in IDR is managed
+
+## Study name 
+
+After acceptance, IDR studies must be named as `idr<NNNN>-<name>-<description>`
+where `idr<NNNN>` is the accession number of the study using an incremental
+four digits integer, `<author>` is the name of one of the authors associated
+with the publication, usually the first author, and `<description>` is a short
+description of the study. The name should be lowercase.
+
+## Study repository 
+
+For each new IDR study, a repository must be created on GitHub under the [IDR](http://github.com/IDR/) organization using the study name as defined above. When ready for publication in the IDR, the study repository must be
+registered in the top-level idr-metadata repository.
+
+Study repository contain all curated metadata files associated with a study.
+The structure of each study repository should use the following layout:
+
+    .travis.yml         # Travis CI configuration file, used for validation
+    bulk.yml            # Optional import configuration file for multi-experiment or multi-screen studies
+    experimentA/        # Curated metadata for experimentA if applicable
+        idrNNNN-experimentA-annotation.csv       # Curated image annotations
+        idrNNNN-experimentA-bulk.yml             # Configuration file for import
+        idrNNNN-experimentA-bulkmap-config.yml   # Configuration file for annotation
+        idrNNNN-experimentA-filePaths.tsv        # Files/folder to be imported
+    experimentB/        # Curated metadata for experimentA if applicable
+       ...
+    idrNNNN-study.txt.  # Top-level metadata file describing the study
+    screenA/            # Curated metadata for screenA if applicable
+        idrNNNN-screenA-annotation.csv           # Curated well annotations
+        idrNNNN-screenA-bulk.yml                 # Configuration file for import
+        idrNNNN-screenA-bulkmap-config.yml       # Configuration file for annotation
+        idrNNNN-screenA-plates.tsv               # Plates to be imported
+    screenB/            # Curated metadata for screenA if applicable
+       ...
+    scripts/            # Folder containing custom scripts associated with the study
+    README.md           # Optional top-level readme
+    requirements.txt    # Python dependencies used for Travis or scripts

--- a/README.md
+++ b/README.md
@@ -20,25 +20,25 @@ registered in the top-level idr-metadata repository.
 Study repository contain all curated metadata files associated with a study.
 The structure of each study repository should use the following layout:
 
-    .travis.yml         # Travis CI configuration file, used for validation (recommended)
-    bulk.yml            # Optional import configuration file for multi-experiment or multi-screen studies (optional)
-    experimentA/        # Curated metadata for experimentA if applicable
+    .travis.yml                                  # Travis CI configuration file, used for validation (recommended)
+    bulk.yml                                     # Import configuration file for multi-experiment or multi-screen studies (optional)
+    experimentA/                                 # Curated metadata for experimentA (if applicable)
         idrNNNN-experimentA-annotation.csv       # Curated annotation file (mandatory)
         idrNNNN-experimentA-assays.txt           # Original annotation file (recommended)
         idrNNNN-experimentA-bulk.yml             # Configuration file for import (mandatory)
         idrNNNN-experimentA-bulkmap-config.yml   # Configuration file for annotation (mandatory)
         idrNNNN-experimentA-filePaths.tsv        # Files/folder to be imported (mandatory)
-    experimentB/        # Curated metadata for experimentA if applicable
+    experimentB/                                 # Curated metadata for experimentA (if applicable)
        ...
-    idrNNNN-study.txt.  # Top-level metadata file describing the study (mandatory)
-    screenA/            # Curated metadata for screenA if applicable
+    idrNNNN-study.txt                            # Top-level metadata file describing the study (mandatory)
+    screenA/                                     # Curated metadata for screenA if applicable
         idrNNNN-screenA-annotation.csv           # Curated annotation file (mandatory)
         idrNNNN-screenA-bulk.yml                 # Configuration file for import (mandatory)
         idrNNNN-screenA-bulkmap-config.yml       # Configuration file for annotation (mandatory)
         idrNNNN-screenA-library.txt              # Original annotation file (recommended)
         idrNNNN-screenA-plates.tsv               # Plates to be imported (mandatory)
-    screenB/            # Curated metadata for screenA if applicable
+    screenB/                                     # Curated metadata for screenA if applicable
        ...
-    scripts/            # Folder containing custom scripts associated with the study (optional)
-    README.md           # Optional top-level readme (optional)
-    requirements.txt    # Python dependencies used for Travis or scripts
+    scripts/                                     # Folder containing custom scripts associated with the study (optional)
+    README.md                                    # Optional top-level readme (optional)
+    requirements.txt                             # Python dependencies used for Travis or scripts (recommended)


### PR DESCRIPTION
Following https://github.com/IDR/idr0050-springer-cytoskeletalsystems/pull/11, this is a proposal to add some public documentation describing some of the conventions used for IDR study repositories. This PR starts this process by describing the IDR study naming convention and the expected layout of a curated study repository. 

Initially, I put this information under the README.md of the idr-metadata. Having such information in this repository makes sense as it describes the layout and rules of all IDR studies. Main caveat is that the README might be buried at the bottom of a growing list of studies. Alternative options I can think of would be:

- a top-level `docs` folder (meaning this could be rendered using [GitHub pages](https://help.github.com/articles/configuring-a-publishing-source-for-github-pages/)
- the IDR website https://github.com/IDR/idr.openmicroscopy.org

Leaving this open for initial feedback. I can certainly imagine enriching such a documentation with the public workflow used for loading a study (image import, annotation, rendering) since the latter is tightly coupled to the study repository layout and conventions. /cc @dominikl 