### PR TITLE
prod64: metadata updates

### DIFF
--- a/idr0012-fuchs-cellmorph/idr0012-study.txt
+++ b/idr0012-fuchs-cellmorph/idr0012-study.txt
@@ -9,7 +9,7 @@ Study Description	Genetic screens for phenotypic similarity have made key contri
 Study Organism	Homo sapiens																																																							
 Study Organism Term Source REF	NCBITaxon																																																							
 Study Organism Term Accession	NCBITaxon_9606																																																							
-Study Screens Number	3																																																							
+Study Screens Number	1																																																							
 Study External URL	http://www.cellmorph.org																																																							
 Study Public Release Date																																																								
 																																																								

--- a/idr0016-wawer-bioactivecompoundprofiling/idr0016-study.txt
+++ b/idr0016-wawer-bioactivecompoundprofiling/idr0016-study.txt
@@ -41,7 +41,7 @@ Term Source URI	http://purl.obolibrary.org/obo/	http://www.ebi.ac.uk/efo/	http:/
 # Screen; this section should be repeated if a study contains multiple screens					
 					
 Screen Number	1				
-Comment[IDR Screen Name]	idr0016-wawer-30kcompounds/screenA				
+Comment[IDR Screen Name]	idr0016-wawer-bioactivecompoundprofiling/screenA				
 Screen Description	Using the cell-painting assay developed by Gustafsdottir et al, 2013, the Broad Institute has assembled a reference dataset of profiles for U2OS osteosarcoma cells treated with ~30,000 compounds. The experiment consisted of 413 microtiter plates. Each plate has 384 wells. Each well has 6 fields of view; a very small fraction of the wells (0.002%) have a few sites missing. Each field was imaged in five channels (detection wavelengths), and each channel is stored as a separate, grayscale 16-bit TIFF image file.				
 Screen Size	Plates: 413	5D Images:	Planes:	Average Image Dimension (XYZCT):	Total Tb:
 Screen Example Images	https://idr.openmicroscopy.org/webclient/?show=well-1215412	https://idr.openmicroscopy.org/webclient/img_detail/2782349/	20586;M8		

--- a/idr0017-breinig-drugscreen/idr0017-study.txt
+++ b/idr0017-breinig-drugscreen/idr0017-study.txt
@@ -11,6 +11,7 @@ Study Organism Term Source REF	NCBITaxon
 Study Organism Term Accession	NCBITaxon_9606																																										
 Study Screens Number	1																																										
 Study External URL	http://dedomena.embl.de/PGPC	http://bioconductor.org/packages/devel/data/experiment/html/PGPC.html																																									
+Study BioStudies Accession	S-BSMS-PGPC1
 Study Public Release Date																																											
 																																											
 # Study Publication																																											
@@ -25,6 +26,9 @@ Study License	CC-BY-NC-ND 4.0
 Study License URL	https://creativecommons.org/licenses/by-nc-nd/4.0/																																										
 Study Copyright	Breinig et al																																										
 																																											
+Study Data Publisher	University of Dundee
+Study Data DOI	https://doi.org/10.17867/10000101
+
 # Study Contacts																																											
 Study Person Last Name	Boutros																																										
 Study Person First Name	Michael																																										

--- a/idr0028-pascualvargas-rhogtpases/idr0028-study.txt
+++ b/idr0028-pascualvargas-rhogtpases/idr0028-study.txt
@@ -43,7 +43,7 @@ Term Source URI	http://purl.obolibrary.org/obo/	http://www.ebi.ac.uk/efo/	http:/
 # Screen; this section should be repeated if a study contains multiple screens																																																																																																																																											
 																																																																																																																																											
 Screen Number	1																																																																																																																																										
-Comment[IDR Screen Name]	idr0028-pascualvargas-rhogtpase/screenA																																																																																																																																										
+Comment[IDR Screen Name]	idr0028-pascualvargas-rhogtpases/screenA																																																																																																																																										
 Screen Data Publisher	University of Dundee																																																																																																																																										
 Screen Data DOI	http://dx.doi.org/10.17867/10000104A																																																																																																																																										
 Screen Description	Human RhoGEF/RhoGAP siGenome siRNA screen on highly metastatic triple negative breast cancer cell line LM2																																																																																																																																										
@@ -114,7 +114,7 @@ Processed Data Column Description	The plate the result comes from	The well the r
 Processed Data Column Link To Library File	Plate_Well																																																																																																																																										
 																																																																																																																																											
 Screen Number	2																																																																																																																																										
-Comment[IDR Screen Name]	idr0028-pascualvargas-rhogtpase/screenB																																																																																																																																										
+Comment[IDR Screen Name]	idr0028-pascualvargas-rhogtpases/screenB																																																																																																																																										
 Screen Data Publisher	University of Dundee																																																																																																																																										
 Screen Data DOI	http://dx.doi.org/10.17867/10000104B																																																																																																																																										
 Screen Description	Human RhoGEF/RhoGAP OnTargetPlus siRNA screen on highly metastatic triple negative breast cancer cell line LM2																																																																																																																																										
@@ -185,7 +185,7 @@ Processed Data Column Description	The plate the result comes from	The well the r
 Processed Data Column Link To Library File	Plate_Well																																																																																																																																										
 																																																																																																																																											
 Screen Number	3																																																																																																																																										
-Comment[IDR Screen Name]	idr0028-pascualvargas-rhogtpase/screenC																																																																																																																																										
+Comment[IDR Screen Name]	idr0028-pascualvargas-rhogtpases/screenC																																																																																																																																										
 Screen Data Publisher	University of Dundee																																																																																																																																										
 Screen Data DOI	http://dx.doi.org/10.17867/10000104C																																																																																																																																										
 Screen Description	Human RhoGEF/RhoGAP siGenome siRNA screen on triple negative breast cancer cell line MDA-MB-231																																																																																																																																										
@@ -256,7 +256,7 @@ Processed Data Column Description	The plate the result comes from	The well the r
 Processed Data Column Link To Library File	Plate_Well																																																																																																																																										
 																																																																																																																																											
 Screen Number	4																																																																																																																																										
-Comment[IDR Screen Name]	idr0028-pascualvargas-rhogtpase/screenD																																																																																																																																										
+Comment[IDR Screen Name]	idr0028-pascualvargas-rhogtpases/screenD																																																																																																																																										
 Screen Data Publisher	University of Dundee																																																																																																																																										
 Screen Data DOI	http://dx.doi.org/10.17867/10000104D																																																																																																																																										
 Screen Description	Human RhoGEF/RhoGAP OnTargetplus siRNA screen on triple negative breast cancer cell line MDA-MB-231																																																																																																																																										

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -8,7 +8,7 @@ import os
 import re
 import sys
 
-logging.basicConfig(level=int(os.environ.get("DEBUG", logging.INFO)))
+logging.basicConfig(level=int(os.environ.get("DEBUG", logging.WARN)))
 log = logging.getLogger("pyidr.study_parser")
 
 TYPES = ["Experiment", "Screen"]

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -8,7 +8,7 @@ import os
 import re
 import sys
 
-logging.basicConfig(level=int(os.environ.get("DEBUG", logging.INFO)))
+logging.basicConfig(level=int(os.environ.get("DEBUG", logging.WARN)))
 log = logging.getLogger("pyidr.study_parser")
 
 TYPES = ["Experiment", "Screen"]
@@ -203,7 +203,6 @@ class StudyParser():
         assert len(titles) == len(authors), (
             "Mismatching publication titles and authors")
         if titles == [''] and authors == ['']:
-            print 'existing'
             return
 
         publications = [{"Title": title, "Author List": author}
@@ -314,8 +313,8 @@ class Formatter(object):
         if component["Study Publication Title"]:
             # Only display the first publication
             publication_title = (
-                "Publication Title\n%(Study Publication Title)s\n\n" %
-                component).split('\t')[0]
+                "Publication Title\n%(Study Publication Title)s" %
+                component).split('\t')[0] + "\n\n"
         if "Type" in component:
             key = "%s Description" % component["Type"]
         else:

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -36,6 +36,7 @@ KEYS = (
     Key('Study Organism Term Source REF', 'Study', optional=True),
     Key('Study Organism Term Accession', 'Study', optional=True),
     # OPTIONAL_KEYS["Study"]
+    Key('Study BioStudies Accession', 'Study', optional=True),
     Key('Study Publication Preprint', 'Study', optional=True),
     Key('Study PubMed ID', 'Study', optional=True),
     Key('Study PMC ID', 'Study', optional=True),
@@ -261,6 +262,9 @@ class Formatter(object):
         ('Data Publisher', "%(Study Data Publisher)s"),
         ('Data DOI', "%(Data DOI)s "
          "https://doi.org/%(Data DOI)s"),
+        ('BioStudies ID', "%(Study BioStudies Accession)s"
+         " https://www.ebi.ac.uk/biostudies/studies/"
+         "%(Study BioStudies Accession)s"),
         ('Annotation File', "%(Annotation File)s"),
     ]
 

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -202,6 +202,10 @@ class StudyParser():
         authors = self.study['Study Author List'].split('\t')
         assert len(titles) == len(authors), (
             "Mismatching publication titles and authors")
+        if titles == [''] and authors == ['']:
+            print 'existing'
+            return
+
         publications = [{"Title": title, "Author List": author}
                         for title, author in zip(titles, authors)]
 
@@ -306,17 +310,19 @@ class Formatter(object):
 
     def generate_description(self, component):
         """Generate the description of the study/experiment/screen"""
-        # Only display the first publication
-        publication_title = (
-            "Publication Title\n%(Study Publication Title)s" %
-            component).split('\t')[0]
+        publication_title = ""
+        if component["Study Publication Title"]:
+            # Only display the first publication
+            publication_title = (
+                "Publication Title\n%(Study Publication Title)s\n\n" %
+                component).split('\t')[0]
         if "Type" in component:
             key = "%s Description" % component["Type"]
         else:
             key = "Study Description"
         component_title = (
             "%s\n%s" % (key, component[key])).decode('string_escape')
-        return publication_title + "\n\n" + component_title
+        return publication_title + component_title
 
     def generate_annotation(self, component):
         """Generate the map annotation of the study/experiment/screen"""
@@ -336,7 +342,7 @@ class Formatter(object):
             add_key_values(component, self.EXPERIMENT_PAIRS)
         elif component.get("Type", None) == "Screen":
             add_key_values(component, self.SCREEN_PAIRS)
-        for publication in component["Publications"]:
+        for publication in component.get("Publications", []):
             add_key_values(publication, self.PUBLICATION_PAIRS)
         add_key_values(component, self.BOTTOM_PAIRS)
         return s

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -24,7 +24,7 @@ class Key(object):
 
 KEYS = (
     # OPTIONAL_KEYS["Study"]
-    Key('Comment\[IDR Study Accession\]', 'Study'),
+    Key(r'Comment\[IDR Study Accession\]', 'Study'),
     Key('Study Title', 'Study'),
     Key('Study Description', 'Study'),
     Key('Study Type', 'Study'),
@@ -59,7 +59,7 @@ KEYS = (
     Key('Term Source Name', 'Study', optional=True),
     Key('Term Source URI', 'Study', optional=True),
     # MANDATORY_KEYS["Experiment"]
-    Key('Comment\[IDR Experiment Name\]', 'Experiment'),
+    Key(r'Comment\[IDR Experiment Name\]', 'Experiment'),
     Key('Experiment Description', 'Experiment'),
     Key('Experiment Imaging Method', 'Experiment'),
     Key('Experiment Number', 'Experiment'),
@@ -67,7 +67,7 @@ KEYS = (
     Key('Experiment Data DOI', 'Experiment', optional=True),
     Key("Experiment Data Publisher", 'Experiment', optional=True),
     # MANDATORY_KEYS["Screen"]
-    Key('Comment\[IDR Screen Name\]', 'Screen'),
+    Key(r'Comment\[IDR Screen Name\]', 'Screen'),
     Key('Screen Description', 'Screen'),
     Key('Screen Imaging Method', 'Screen'),
     Key('Screen Number', 'Screen'),
@@ -148,7 +148,7 @@ class StudyParser():
         return d
 
     def get_lines(self, index, component_type):
-        PATTERN = re.compile("^%s Number\t(\d+)" % component_type)
+        PATTERN = re.compile(r"^%s Number\t(\d+)" % component_type)
         found = False
         lines = []
         for idx, line in enumerate(self._study_lines):
@@ -166,9 +166,9 @@ class StudyParser():
         return lines
 
     def parse_annotation_file(self, component):
-        accession_number = component["Comment\[IDR Study Accession\]"]
-        pattern = re.compile("(%s-\w+(-\w+)?)/(\w+)$" % accession_number)
-        name = component["Comment\[IDR %s Name\]" % component["Type"]]
+        accession_number = component[r"Comment\[IDR Study Accession\]"]
+        pattern = re.compile(r"(%s-\w+(-\w+)?)/(\w+)$" % accession_number)
+        name = component[r"Comment\[IDR %s Name\]" % component["Type"]]
         m = pattern.match(name)
         if not m:
             raise Exception("Unmatched name %s" % name)
@@ -218,8 +218,8 @@ class StudyParser():
                     raise Exception("Invalid %s: %s" % (key2, split_ids[i]))
                 publications[i][key2] = m.group("id")
 
-        parse_ids("Study PubMed ID", re.compile("(?P<id>\d+)"))
-        parse_ids("Study PMC ID", re.compile("(?P<id>PMC\d+)"))
+        parse_ids("Study PubMed ID", re.compile(r"(?P<id>\d+)"))
+        parse_ids("Study PMC ID", re.compile(r"(?P<id>PMC\d+)"))
         parse_ids("Study DOI", DOI_PATTERN)
 
         self.study["Publications"] = publications
@@ -281,7 +281,7 @@ class Formatter(object):
 
         # Serialize experiments/screens
         for component in self.parser.components:
-            name = component["Comment\[IDR %s Name\]" % component["Type"]]
+            name = component[r"Comment\[IDR %s Name\]" % component["Type"]]
             d = {
               "name": name,
               "description": self.generate_description(component),

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -265,7 +265,7 @@ class Formatter(object):
         ('Data Publisher', "%(Study Data Publisher)s"),
         ('Data DOI', "%(Data DOI)s "
          "https://doi.org/%(Data DOI)s"),
-        ('BioStudies ID', "%(Study BioStudies Accession)s"
+        ('BioStudies Accession', "%(Study BioStudies Accession)s"
          " https://www.ebi.ac.uk/biostudies/studies/"
          "%(Study BioStudies Accession)s"),
         ('Annotation File', "%(Annotation File)s"),

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -8,7 +8,7 @@ import os
 import re
 import sys
 
-logging.basicConfig(level=int(os.environ.get("DEBUG", logging.WARN)))
+logging.basicConfig(level=int(os.environ.get("DEBUG", logging.INFO)))
 log = logging.getLogger("pyidr.study_parser")
 
 TYPES = ["Experiment", "Screen"]
@@ -277,7 +277,7 @@ class Formatter(object):
         self.basedir = os.path.dirname(parser._study_file)
         self.inspect = inspect
         self.m = {
-          "name": self.basedir,
+          "name": os.path.basename(self.basedir),
           "source": self.parser._study_file,
           "experiments": [],
           "screens": [],
@@ -380,7 +380,7 @@ class Formatter(object):
 
         cli = CLI()
         cli.loadplugins()
-        cli.onecmd('login')
+        cli.onecmd('login -q')
 
         try:
             gateway = BlitzGateway(client_obj=cli.get_client())


### PR DESCRIPTION
Updates for a couple of historical studies to match the annotations in IDR.
In addition, the `study_parser` logic is updated to read and consume the BioStudies accession number if available. A few studies have such a number (idr0017, idr0030) and others might need it updated as well. 

The changes have been tested against `test64` using `python pyidr/study_parser.py --check`. Reviewing this PR should mostly involve making sure the study file changes are correct.

a few adjustments will be required on `prod64`.