### PR TITLE
Study parser multiple annotation

### DIFF
--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -210,7 +210,7 @@ class StudyParser():
             component["Annotations"].append({
                 "Annotation File": "%s %s" % (
                     os.path.basename(annotation_filename),
-                    base_gh_url + "/%s" %
+                    base_gh_url + "%s" %
                     annotation_filename[len(component_path):])
             })
         return

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -397,7 +397,7 @@ class Formatter(object):
             raise StudyError
 
         if anns[0].getValue() != expected_pairs:
-            log.error("Mismatching description: current:%s\nexpected:%s" %
+            log.error("Mismatching map annotation: current:%s\nexpected:%s" %
                       (anns[0].getValue(), expected_pairs))
             raise StudyError
 


### PR DESCRIPTION
## Proposal

Most of the annotations published IDR studies have been updated to match the curated study file.

We still have some divergences for `idr0043`. One is related a simple field that needs to be modified (`Study Copyright`). The second issue is that the  current study annotation is expected a single `annotation.csv[.gz]` file. In the case of HPA. given to the incremental process, one annotation is created per publication batch.

The proposal is to modify the `study_parser` and the annotation on IDR to list all the associated annotation CSV files at the bottom of the map annotations

## Changes

This change makes the change allowing support for multiple annotation files. All annotation files should be still name `idrXXXX-{experiment,screen}[A-Z]-annotation.csv[.gz]` but can be located deeper in the hierarchy.


e332ddd also includes a simplification of the checking logic against a running IDR which raises an error on mismatch and allows the introduction of a `--set` option to automatically generate/update descriptions and map annotations (upcoming PR)

## Testing this PR

The JSON output of the parsing/annotation formatting can be reviewed by using the `--report` option e.g.

```
python pyidr/study_parser.py idr0001-graml-sysgro/idr0001-study.txt --report
...
python pyidr/study_parser.py idr0043-uhlen-humanproteinatlas/idr0043-study.txt --report
python pyidr/study_parser.py idr0044-mcdole-tardislightsheet/idr0044-study.txt --report
...
```

For all studies, it should be unchanged from previously. For `idr0043`, the `Annotation File` key should be replicated for each `.csv.gz` file.

It can be tested against a running server using the `--check` option (with the `PYTHONPATH` correctly set) e.g. `idr.openmicroscopy.org`

```
python pyidr/study_parser.py idr0001-graml-sysgro/idr0001-study.txt --check
...
python pyidr/study_parser.py idr0043-uhlen-humanproteinatlas/idr0043-study.txt --check
python pyidr/study_parser.py idr0044-mcdole-tardislightsheet/idr0044-study.txt --check
...
```

In the current representation, I would expect all checks to pass except `idr0043` which will be modified to match the changes of this PR and the multi-experiments or multi-screens studies `idr0028` and `idr0038` as the `Study` annotations are not covered yet.
