### PR TITLE
Make Study Public Release Date mandatory

### DIFF
--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -48,7 +48,7 @@ KEYS = (
     Key('Study Experiments Number', 'Study', optional=True),
     Key('Study Screens Number', 'Study', optional=True),
     Key('Study External URL', 'Study', optional=True),
-    Key('Study Public Release Date', 'Study', optional=True),
+    Key('Study Public Release Date', 'Study'),
     Key('Study Person Last Name', 'Study', optional=True),
     Key('Study Person First Name', 'Study', optional=True),
     Key('Study Person Email', 'Study', optional=True),


### PR DESCRIPTION
The work on the gallery front-end of IDR has led us to populating the `Study Public Release Date` of the study file in order to display the most recent published studies.

This change should ensure no study repository is added to this top-level repository without a release date so that the study is always annotated with this metadata.