### PR TITLE
Add idr0075-cabirol-honeybee

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -95,3 +95,6 @@
 [submodule "idr0073-schaadt-immuneinfiltrates"]
 	path = idr0073-schaadt-immuneinfiltrates
 	url = git://github.com/IDR/idr0073-schaadt-immuneinfiltrates
+[submodule "idr0075-cabirol-honeybee"]
+	path = idr0075-cabirol-honeybee
+	url = git://github.com/IDR/idr0075-cabirol-honeybee


### PR DESCRIPTION
On `prod74` I ran
```
git pull origin master
git submodule sync
git submodule init
git submodule update
git status
```
```
# On branch master
# Your branch is ahead of 'origin/master' by 4 commits.
#   (use "git push" to publish your local commits)
#
# Changes not staged for commit:
#   (use "git add <file>..." to update what will be committed)
#   (use "git checkout -- <file>..." to discard changes in working directory)
#   (commit or discard the untracked or modified content in submodules)
#
#       modified:   idr0069-caldera-perturbome (untracked content)
#
# Untracked files:
#   (use "git add <file>..." to include in what will be committed)
#
#       idr0015-UNKNOWN-taraoceans/name.cut
#       idr0015-UNKNOWN-taraoceans/taraoceans.BULK_ANNOTATION.csv
#       idr0075-cabirol-honeybee/
no changes added to commit (use "git add" and/or "git commit -a")
```

`idr0075-cabirol-honeybee` was checked out as a directory but not added as a submodule.

We should probably clean the rest of those files up too