### PR TITLE
Add Checklist for study release

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+<!--
+If you are not releasing an IDR study you can delete this 😀
+-->
+
+## IDR study release checklist
+
+- [ ] All import paths are under `/uod/idr`
+- [ ] Images are rendered correctly
+- [ ] Study annotations are updated
+- [ ] Study stats are updated
+- [ ] Cache is updated, especially Mapr


### PR DESCRIPTION
Move some of the former trello checklist items to a PR template, so items can be ticked off for individual studies when they're added to this repo.